### PR TITLE
Dannym socket auth

### DIFF
--- a/nmosoauth/resource_server/nmos_security.py
+++ b/nmosoauth/resource_server/nmos_security.py
@@ -133,10 +133,12 @@ class NmosSecurity(object):
                     try:
                         auth_string = parse_qs(query_string)['authorization'][0]
                     except KeyError:
-                        self.logger.writeError("'authorization' URL param doesn't exist. Websocket authentication failed.")
+                        self.logger.writeError("""
+                            'authorization' URL param doesn't exist. Websocket authentication failed.
+                        """)
                         raise MissingAuthorizationError()
                 self.processAccessToken(auth_string)
-            except AuthlibBaseError as e:
+            except AuthlibBaseError:
                 err = {"type": "error", "data": "Socket Authentication Error"}
                 ws.send(json.dumps(err))
                 raise


### PR DESCRIPTION
Send socket error message when socket authentication fails (will be picked up by:
https://github.com/bbc/nmos-web-router/blob/eec9b2a7b0950f91d1c2e283171be1b9a0500787/src/web-router/dispatchers/initialise-dispatcher.js#L70)
