### PR TITLE
Fix Authorization endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # NMOS Authorization API Implementation Changelog
 
+## 1.0.6
+- Fix Authorization endpoint.
+
 ## 1.0.5
 - Add ability to load external config. Load static elements locally for running offline.
 

--- a/nmosauth/auth_server/db_utils.py
+++ b/nmosauth/auth_server/db_utils.py
@@ -46,9 +46,10 @@ def addAccessRights(user, IS04Access, IS05Access):
 
 
 def addUser(username, password):
-    user = User(username=username, password=password)
-    add(user)
-    return user
+    if User.query.filter_by(username=username).scalar() is None:
+        user = User(username=username, password=password)
+        add(user)
+        return user
 
 # -------------------- READ ------------------------- #
 # from nmosauth.auth_server.db_utils import *

--- a/nmosauth/auth_server/security_api.py
+++ b/nmosauth/auth_server/security_api.py
@@ -120,7 +120,8 @@ class SecurityAPI(WebAPI):
         if not username or not password:
             return redirect(url_for('_signup_get'))
         user = addUser(username, password)
-
+        if user is None:
+            return render_template('signup.html', message="Invalid Username. Please choose another one.")
         is04 = request.form.get('is04', None)
         is05 = request.form.get('is05', None)
         addAccessRights(user, is04, is05)
@@ -183,7 +184,7 @@ class SecurityAPI(WebAPI):
         if not user and 'username' in request.form:
             username = request.form.get('username')
             user = User.query.filter_by(username=username).first()
-        if request.form['confirm']:
+        if "confirm" in request.form.keys() and request.form['confirm'] == "true":
             grant_user = user
         else:
             grant_user = None
@@ -194,6 +195,8 @@ class SecurityAPI(WebAPI):
         user = self.current_user()
         if not user and request.authorization:
             user = getUser(request.authorization.username)
+        elif not user:
+            return redirect(url_for('_home'))
         try:
             grant = authorization.validate_consent_request(end_user=user, request=request)
         except OAuth2Error as error:

--- a/nmosauth/auth_server/security_api.py
+++ b/nmosauth/auth_server/security_api.py
@@ -102,7 +102,10 @@ class SecurityAPI(WebAPI):
                 return render_template('home.html', user=None, clients=None, message=message)
             if user.password == password:
                 session['id'] = user.id
-                return redirect(url_for('_home'))
+                if "redirect" in session:
+                    return redirect(session['redirect'])
+                else:
+                    return redirect(url_for('_home'))
             else:
                 message = "Invalid Password. Try Again."
                 return render_template('home.html', user=None, clients=None, message=message)
@@ -195,7 +198,8 @@ class SecurityAPI(WebAPI):
         user = self.current_user()
         if not user and request.authorization:
             user = getUser(request.authorization.username)
-        elif not user:
+        if not user:
+            session["redirect"] = request.url
             return redirect(url_for('_home'))
         try:
             grant = authorization.validate_consent_request(end_user=user, request=request)

--- a/nmosauth/auth_server/templates/authorize.html
+++ b/nmosauth/auth_server/templates/authorize.html
@@ -15,7 +15,7 @@ limitations under the License. -->
 {% extends "layout.html" %}
 {% block body %}
 <h2>Authorization</h2>
-<p>{{grant.client.client_name}} is requesting with a scope of:
+<p>{{ grant.client.client_name }} is requesting with a scope of:
 <b>{{ grant.request.scope }}</b>
 </p>
 
@@ -25,6 +25,7 @@ limitations under the License. -->
     <input type="hidden" name="response_type" value="code">
     <input type="hidden" name="client_id" value="{{ grant.client.client_id }}">
     <input type="hidden" name="redirect_uri" value="{{ request.args.get('redirect_uri') }}">
+    <input type="hidden" name="state" value="{{ request.args.get('state') }}">
     <input type="checkbox" name="confirm" value="true">
   </label>
   <br>

--- a/nmosauth/auth_server/templates/authorize.html
+++ b/nmosauth/auth_server/templates/authorize.html
@@ -19,17 +19,14 @@ limitations under the License. -->
 <b>{{ grant.request.scope }}</b>
 </p>
 
-<form action="" method="post">
+<form action="{{ url_for('_authorization_post') }}" method="post">
   <label>
-    <input type="checkbox" name="confirm">
-    <span>Consent?</span>
+    <span>Do You Approve This Access?</span>
+    <input type="hidden" name="response_type" value="code">
+    <input type="hidden" name="client_id" value="{{ grant.client.client_id }}">
+    <input type="hidden" name="redirect_uri" value="{{ request.args.get('redirect_uri') }}">
+    <input type="checkbox" name="confirm" value="true">
   </label>
-  {% if not user %}
-  <p>You haven't logged in. Log in with:</p>
-  <div>
-    <input type="text" name="username">
-  </div>
-  {% endif %}
   <br>
   <button>Submit</button>
 </form>

--- a/nmosauth/auth_server/templates/signup.html
+++ b/nmosauth/auth_server/templates/signup.html
@@ -44,4 +44,6 @@ limitations under the License. -->
   <button type="submit">Signup</button>
 </form>
 
+<div><p>{{ message }}</p></div>
+
 {% endblock %}

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ GEN_CERT_PATH = os.path.join(NMOSAUTH_DIR, GEN_CERT_FILE)
 
 # Basic metadata
 name = "nmos-auth"
-version = "1.0.5"
+version = "1.0.6"
 description = "OAuth2 Server Implementation"
 url = 'https://github.com/bbc/nmos-auth-server'
 author = 'Danny Meloy'


### PR DESCRIPTION
Fixed a few bugs concerning:
- Catching error when attempting to register same user twice
- Preventing error when "confirm" tickbox wasn't selected at authorization stage
- Passing of query parameters as form data for Authorization Grant parameters (avoids missing redirect_uri issue)
- Correct redirection of non-logged in users to authorize page with correct query params
