### PR TITLE
allow clients to register using json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # NMOS Authorization API Implementation Changelog
 
+## 1.0.9
+- Allow clients to register using JSON in-line with RFC7591. Change imports in-line with Authlib v0.11 release.
+
 ## 1.0.8
 - Pin versions of PyOpenSSL and Cryptography to force package upgrades.
 

--- a/nmosauth/auth_server/constants.py
+++ b/nmosauth/auth_server/constants.py
@@ -22,5 +22,4 @@ CERT_PATH = os.path.join(NMOSAUTH_DIR, CERT_FILE)
 PRIVKEY_FILE = 'privkey.pem'
 PRIVKEY_PATH = os.path.join(NMOSAUTH_DIR, PRIVKEY_FILE)
 CERT_ENDPOINT = '/certs'
-CERT_KEY = 'default'
 DATABASE_NAME = 'auth_db'

--- a/nmosauth/auth_server/models.py
+++ b/nmosauth/auth_server/models.py
@@ -19,7 +19,7 @@ from authlib.flask.oauth2.sqla import (
     OAuth2AuthorizationCodeMixin,
     OAuth2TokenMixin,
 )
-from authlib.specs.rfc6749.errors import OAuth2Error
+from authlib.oauth2 import OAuth2Error
 
 __all__ = ['db', 'User', 'OAuth2Client',
            'OAuth2AuthorizationCode', 'OAuth2Token', 'AccessRights']

--- a/nmosauth/auth_server/oauth2.py
+++ b/nmosauth/auth_server/oauth2.py
@@ -19,8 +19,8 @@ from authlib.flask.oauth2.sqla import (
     create_revocation_endpoint,
     create_bearer_token_validator,
 )
-from authlib.specs.rfc6749 import grants
-from authlib.specs.rfc6749.errors import InvalidRequestError
+from authlib.oauth2.rfc6749 import grants
+from authlib.oauth2.rfc6749.errors import InvalidRequestError
 from werkzeug.security import gen_salt
 from .models import db, User, OAuth2Client, OAuth2AuthorizationCode, OAuth2Token
 

--- a/nmosauth/auth_server/token_generator.py
+++ b/nmosauth/auth_server/token_generator.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import os
-from authlib.specs.rfc7519 import jwt
+from authlib.jose import jwt
 import datetime
 from .oauth2 import authorization
 from .models import AccessRights

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ GEN_CERT_PATH = os.path.join(NMOSAUTH_DIR, GEN_CERT_FILE)
 
 # Basic metadata
 name = "nmos-auth"
-version = "1.0.8"
+version = "1.0.9"
 description = "OAuth2 Server Implementation"
 url = 'https://github.com/bbc/nmos-auth-server'
 author = 'Danny Meloy'


### PR DESCRIPTION
Allow clients to register using JSON input, and changed auythlib imports in-line with deprecation notice (https://git.io/fjvpt)