### PR TITLE
change JWT alg to RS512 and unify scope definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # NMOS Authorization API Implementation Changelog
 
+## 1.0.10
+- Change JWT signing algorithm to RS512 in line with BCP-001-02. Alter default scope for Bearer token to be same as in access token.
+
 ## 1.0.9
 - Allow clients to register using JSON in-line with RFC7591. Change imports in-line with Authlib v0.11 release.
 

--- a/nmosauth/auth_server/models.py
+++ b/nmosauth/auth_server/models.py
@@ -75,6 +75,7 @@ class OAuth2Token(db.Model, OAuth2TokenMixin):
     user_id = db.Column(
         db.Integer, db.ForeignKey('user.id', ondelete='CASCADE'))
     user = db.relationship('User')
+    access_token = db.Column(db.String(255), nullable=False, unique=False)
 
     def is_refresh_token_expired(self):
         expires_at = self.issued_at + self.expires_in * 2

--- a/nmosauth/auth_server/settings.py
+++ b/nmosauth/auth_server/settings.py
@@ -33,7 +33,7 @@ class BaseConfig(object):
     OAUTH2_REFRESH_TOKEN_GENERATOR = True
     OAUTH2_JWT_ENABLED = True
     OAUTH2_JWT_ISS = 'http://rd.bbc.co.uk/x-nmos/auth/v1.0/'
-    OAUTH2_JWT_ALG = 'RS256'
+    OAUTH2_JWT_ALG = 'RS512'
     OAUTH2_JWT_EXP = 60
     OAUTH2_JWT_KEY_PATH = PRIVKEY_PATH
 

--- a/nmosauth/auth_server/templates/create_client.html
+++ b/nmosauth/auth_server/templates/create_client.html
@@ -29,7 +29,7 @@ limitations under the License. -->
   </label>
   <label>
     <span>Allowed Scope:</span>
-    <input type="text" name="scope" value="is04 is05"
+    <input type="text" name="scope" value="is-04 is-05"
             placeholder="space delimited list of scopes">
   </label>
   <label>

--- a/nmosauth/auth_server/templates/fetch_token.html
+++ b/nmosauth/auth_server/templates/fetch_token.html
@@ -44,8 +44,8 @@ limitations under the License. -->
   <label>
     <span>Scope:</span>
     <select name="scope" id="scope">
-        <option value="is04">IS-04</option>
-        <option value="is05">IS-05</option>
+        <option value="is-04">IS-04</option>
+        <option value="is-05">IS-05</option>
     </select>
     <br>
   </label>

--- a/nmosauth/auth_server/token_generator.py
+++ b/nmosauth/auth_server/token_generator.py
@@ -26,10 +26,10 @@ class TokenGenerator():
         pass
 
     def get_access_rights(self, user, scope):
-        if scope == "is04":
+        if scope == "is-04":
             user_access = AccessRights.query.filter_by(user_id=user.id).first()
             access = user_access.is04
-        elif scope == "is05":
+        elif scope == "is-05":
             user_access = AccessRights.query.filter_by(user_id=user.id).first()
             access = user_access.is05
         else:
@@ -40,12 +40,12 @@ class TokenGenerator():
         audience = ''
         if access is None:
             return None
-        if scope == "is04":
+        if scope == "is-04":
             if access == "write":
                 audience = "IS-04 Write Access".split(" ")
             if access == "read":
                 audience = "IS-04 Read Access".split(" ")
-        elif scope == "is05":
+        elif scope == "is-05":
             if access == "write":
                 audience = "IS-05 Write Access".split(" ")
             if access == "read":

--- a/nmosauth/certs/gen_cert.py
+++ b/nmosauth/certs/gen_cert.py
@@ -25,7 +25,7 @@ def create_self_signed_cert():
     cert.gmtime_adj_notAfter(10 * 365 * 24 * 60 * 60)
     cert.set_issuer(cert.get_subject())
     cert.set_pubkey(k)
-    cert.sign(k, 'sha256')
+    cert.sign(k, 'sha512')
 
     # Write Cert and Private Key to File
     open(CERT_PATH, "wt").write(

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ GEN_CERT_PATH = os.path.join(NMOSAUTH_DIR, GEN_CERT_FILE)
 
 # Basic metadata
 name = "nmos-auth"
-version = "1.0.9"
+version = "1.0.10"
 description = "OAuth2 Server Implementation"
 url = 'https://github.com/bbc/nmos-auth-server'
 author = 'Danny Meloy'


### PR DESCRIPTION
Change JWT algorithm in line with BCP-003-002 from RS256 to RS512, and unify the scope definitions so they are all "is-04, is-05" etc. to resolve https://github.com/AMWA-TV/nmos-api-security/issues/37

Also, temporary removal of unique constraint on access tokens to prevent test failures and failures when making sequential requests. Ultimately duplications of access tokens won't inhibit the ability for associated refresh tokens to be blacklisted or for them to expire.