### PR TITLE
Dannym Minor Version Bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # NMOS Authorization API Implementation Changelog
 
+## 1.0.11
+- Change scripts to run using Python3. Change 'iss' and 'aud' JWT claim generation.
+
 ## 1.0.10
 - Change JWT signing algorithm to RS512 in line with BCP-001-02. Alter default scope for Bearer token to be same as in access token.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # NMOS Authorization API Implementation Changelog
 
-## 1.0.11
+## 1.1.0
 - Change scripts to run using Python3. Change 'iss' and 'aud' JWT claim generation.
 
 ## 1.0.10

--- a/bin/nmosauth
+++ b/bin/nmosauth
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 import os
 

--- a/bin/nmosauth
+++ b/bin/nmosauth
@@ -1,11 +1,7 @@
 #!/usr/bin/python3
 
-import os
-
 if __name__ == "__main__":
     from nmosauth.auth_server.security_service import SecurityService
-
-    os.environ["AUTHLIB_INSECURE_TRANSPORT"] = "1"
 
     service = SecurityService()
     service.run()

--- a/bin/nmosauth
+++ b/bin/nmosauth
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 if __name__ == "__main__":
     from nmosauth.auth_server.security_service import SecurityService

--- a/nmosauth/auth_server/db_utils.py
+++ b/nmosauth/auth_server/db_utils.py
@@ -74,11 +74,14 @@ def printField(table, field):
 
 
 def getUser(user):
-    if isinstance(user, int):
-        entry = User.query.get_or_404(user)
-    elif isinstance(user, str):
-        entry = User.query.filter_by(username=user).first_or_404()
-    return entry
+    try:
+        if isinstance(user, int):
+            entry = User.query.get_or_404(user)
+        elif isinstance(user, str):
+            entry = User.query.filter_by(username=user).first_or_404()
+        return entry
+    except Exception:
+        return None
 
 
 def printForeign(table, key, val):  # Key is usually user_id

--- a/nmosauth/auth_server/db_utils.py
+++ b/nmosauth/auth_server/db_utils.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from six import string_types
 from .models import db, User, OAuth2Client, AccessRights
 
 # -------------------- INIT ------------------------- #
@@ -77,7 +78,7 @@ def getUser(user):
     try:
         if isinstance(user, int):
             entry = User.query.get_or_404(user)
-        elif isinstance(user, str):
+        elif isinstance(user, string_types):
             entry = User.query.filter_by(username=user).first_or_404()
         return entry
     except Exception:
@@ -116,7 +117,7 @@ def remove(entry):
 def removeUser(user):
     if isinstance(user, int):
         entry = User.query.get_or_404(user)
-    elif isinstance(user, str):
+    elif isinstance(user, string_types):
         entry = User.query.filter_by(username=user).first_or_404()
     remove(entry)
 

--- a/nmosauth/auth_server/security_api.py
+++ b/nmosauth/auth_server/security_api.py
@@ -189,8 +189,8 @@ class SecurityAPI(WebAPI):
         user = self.current_user()
         if not user and request.authorization:
             user = getUser(request.authorization.username)
-        if not user or not user.check_password(request.authorization.password):
-            raise InvalidRequestError
+            if not user or not user.check_password(request.authorization.password):
+                raise InvalidRequestError
         if "confirm" in request.form.keys() and request.form['confirm'] == "true":
             grant_user = user
         else:

--- a/nmosauth/auth_server/security_service.py
+++ b/nmosauth/auth_server/security_service.py
@@ -20,7 +20,7 @@ import gevent  # noqa E402
 import time  # noqa E402
 import signal  # noqa E402
 from socket import gethostname  # noqa E402
-from os import getpid, path   # noqa E402
+from os import getpid, path, environ   # noqa E402
 import json  # noqa E402
 
 from nmoscommon.httpserver import HttpServer  # noqa E402
@@ -28,6 +28,7 @@ from nmoscommon.mdns import MDNSEngine  # noqa E402
 from nmoscommon.logger import Logger  # noqa E402
 from .security_api import SecurityAPI  # noqa E402
 
+environ["AUTHLIB_INSECURE_TRANSPORT"] = "1"
 
 PORT = 4999
 HOSTNAME = gethostname().split(".", 1)[0]

--- a/nmosauth/auth_server/settings.py
+++ b/nmosauth/auth_server/settings.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+import socket
 from datetime import timedelta
 from .constants import NMOSAUTH_DIR, PRIVKEY_PATH, DATABASE_NAME
 
@@ -32,7 +33,7 @@ class BaseConfig(object):
     OAUTH2_ACCESS_TOKEN_GENERATOR = pkg + 'token_generator.gen_token'
     OAUTH2_REFRESH_TOKEN_GENERATOR = True
     OAUTH2_JWT_ENABLED = True
-    OAUTH2_JWT_ISS = 'http://rd.bbc.co.uk/x-nmos/auth/v1.0/'
+    OAUTH2_JWT_ISS = socket.getfqdn()
     OAUTH2_JWT_ALG = 'RS512'
     OAUTH2_JWT_EXP = 60
     OAUTH2_JWT_KEY_PATH = PRIVKEY_PATH

--- a/nmosauth/auth_server/static/style.css
+++ b/nmosauth/auth_server/static/style.css
@@ -26,14 +26,14 @@ h2 {
   color: #555;
 }
 
-button {
+button, .button {
   padding: 10px 20px;
   background-color: #ccc;
   border: none;
   font-size: 1em;
 }
 
-button:hover {
+button:hover, .button:hover {
   background-color: #777;
 }
 

--- a/nmosauth/auth_server/templates/authorize.html
+++ b/nmosauth/auth_server/templates/authorize.html
@@ -19,13 +19,21 @@ limitations under the License. -->
 <b>{{ grant.request.scope }}</b>
 </p>
 
-<form action="{{ url_for('_authorization_post') }}" method="post">
+<form action="{{ url_for(
+                  '_authorization_post',
+                  response_type=request.args.get('response_type'),
+                  client_id=request.args.get('client_id'),
+                  scope=request.args.get('scope'),
+                  redirect_uri=request.args.get('redirect_uri'),
+                  state=request.args.get('state')
+              ) }}" method="post">
   <label>
     <span>Do You Approve This Access?</span>
-    <input type="hidden" name="response_type" value="code">
+    <!-- <input type="hidden" name="response_type" value="code">
     <input type="hidden" name="client_id" value="{{ grant.client.client_id }}">
     <input type="hidden" name="redirect_uri" value="{{ request.args.get('redirect_uri') }}">
-    <input type="hidden" name="state" value="{{ request.args.get('state') }}">
+    <input type="hidden" name="scope" value="{{ request.args.get('scope') }}">
+    <input type="hidden" name="state" value="{{ request.args.get('state') }}"> -->
     <input type="checkbox" name="confirm" value="true">
   </label>
   <br>

--- a/nmosauth/auth_server/templates/authorize.html
+++ b/nmosauth/auth_server/templates/authorize.html
@@ -29,11 +29,6 @@ limitations under the License. -->
               ) }}" method="post">
   <label>
     <span>Do You Approve This Access?</span>
-    <!-- <input type="hidden" name="response_type" value="code">
-    <input type="hidden" name="client_id" value="{{ grant.client.client_id }}">
-    <input type="hidden" name="redirect_uri" value="{{ request.args.get('redirect_uri') }}">
-    <input type="hidden" name="scope" value="{{ request.args.get('scope') }}">
-    <input type="hidden" name="state" value="{{ request.args.get('state') }}"> -->
     <input type="checkbox" name="confirm" value="true">
   </label>
   <br>

--- a/nmosauth/auth_server/templates/home.html
+++ b/nmosauth/auth_server/templates/home.html
@@ -57,15 +57,14 @@ limitations under the License. -->
     </script>
 
 
-
   {% else %}
     <h2>Log In</h2>
     <form action="" method="post">
       <p><input type="text" name="username" placeholder="username"></p>
       <p><input type="password" name="password"  placeholder="password"></p>
-      <button type="submit">Login</button>
+      <button type="submit">Log-in</button>
     </form>
-    <p><a href="{{ url_for('_signup_get') }}">Signup</a></p>
+    <p><a class="button" href="{{ url_for('_signup_get') }}">Signup</a></p>
   {% endif %}
 
   <div><p>{{ message }}</p></div>

--- a/nmosauth/auth_server/token_generator.py
+++ b/nmosauth/auth_server/token_generator.py
@@ -26,15 +26,18 @@ class TokenGenerator():
         pass
 
     def get_access_rights(self, user, scope):
-        if scope == "is-04":
-            user_access = AccessRights.query.filter_by(user_id=user.id).first()
-            access = user_access.is04
-        elif scope == "is-05":
-            user_access = AccessRights.query.filter_by(user_id=user.id).first()
-            access = user_access.is05
+        if user is None:
+            return "client_credentials"
         else:
-            access = None
-        return access
+            if scope == "is-04":
+                user_access = AccessRights.query.filter_by(user_id=user.id).first()
+                access = user_access.is04
+            elif scope == "is-05":
+                user_access = AccessRights.query.filter_by(user_id=user.id).first()
+                access = user_access.is05
+            else:
+                access = None
+            return access
 
     def get_audience(self, user, scope, access):
         audience = ''
@@ -68,6 +71,7 @@ class TokenGenerator():
         current_time = datetime.datetime.utcnow()
         access = self.get_access_rights(user, scope)
         audience = self.get_audience(user, scope, access)
+        subject = user.username if user is not None else None
         new_scope = self.get_scope(user, client, scope)
 
         header = {
@@ -79,7 +83,7 @@ class TokenGenerator():
             'exp': current_time + datetime.timedelta(seconds=config['jwt_exp']),
             'nbf': current_time,
             'iss': config['jwt_iss'],
-            'sub': user.username,
+            'sub': subject,
             'scope': new_scope,
             'aud': audience,
             'x-nmos-api': {

--- a/nmosauth/auth_server/token_generator.py
+++ b/nmosauth/auth_server/token_generator.py
@@ -39,23 +39,22 @@ class TokenGenerator():
                 access = None
             return access
 
-    def get_audience(self, user, scope, access):
-        audience = ''
-        if access is None:
-            return None
-        if scope == "is-04":
-            if access == "write":
-                audience = "IS-04 Write Access".split(" ")
-            if access == "read":
-                audience = "IS-04 Read Access".split(" ")
-        elif scope == "is-05":
-            if access == "write":
-                audience = "IS-05 Write Access".split(" ")
-            if access == "read":
-                audience = "IS-04 Read Access".split(" ")
+    def get_audience(self, scope, access):
+        audience = []
+        if access is not None:
+            if scope == "is-04":
+                audience = [
+                    "registry",
+                    "query"
+                ]
+            elif scope == "is-05":
+                audience = [
+                    "senders",
+                    "receivers"
+                ]
         return audience
 
-    def get_scope(self, user, client, scope):
+    def get_scope(self, scope):
 
         if scope in ["is04", "IS04", "is-04", "IS-04"]:
             new_scope = "is-04"
@@ -70,9 +69,9 @@ class TokenGenerator():
         config = authorization.config
         current_time = datetime.datetime.utcnow()
         access = self.get_access_rights(user, scope)
-        audience = self.get_audience(user, scope, access)
+        audience = self.get_audience(scope, access)
         subject = user.username if user is not None else None
-        new_scope = self.get_scope(user, client, scope)
+        new_scope = self.get_scope(scope)
 
         header = {
             "alg": config["jwt_alg"],

--- a/nmosauth/certs/gen_cert.py
+++ b/nmosauth/certs/gen_cert.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 from OpenSSL import crypto
 import os

--- a/nmosauth/certs/gen_cert.py
+++ b/nmosauth/certs/gen_cert.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 from OpenSSL import crypto
 import os

--- a/nmosauth/certs/gen_cert.py
+++ b/nmosauth/certs/gen_cert.py
@@ -29,7 +29,7 @@ def create_self_signed_cert():
 
     # Write Cert and Private Key to File
     open(CERT_PATH, "wt").write(
-        (crypto.dump_certificate(crypto.FILETYPE_PEM, cert).decode('utf-8'))
+        crypto.dump_certificate(crypto.FILETYPE_PEM, cert).decode('utf-8')
     )
     open(PRIVKEY_PATH, "wt").write(
         crypto.dump_privatekey(crypto.FILETYPE_PEM, k).decode('utf-8')

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 #
 # Copyright 2019 British Broadcasting Corporation
 #
@@ -29,7 +29,7 @@ GEN_CERT_PATH = os.path.join(NMOSAUTH_DIR, GEN_CERT_FILE)
 
 # Basic metadata
 name = "nmos-auth"
-version = "1.0.10"
+version = "1.0.11"
 description = "OAuth2 Server Implementation"
 url = 'https://github.com/bbc/nmos-auth-server'
 author = 'Danny Meloy'
@@ -115,7 +115,9 @@ setup(
     package_dir=packages,
     install_requires=packages_required,
     include_package_data=True,
-    scripts=[],
+    scripts=[
+        'bin/nmosauth'
+    ],
     package_data={
         'nmosauth': ['auth_server/templates/*', 'auth_server/static/*']
     },

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ GEN_CERT_PATH = os.path.join(NMOSAUTH_DIR, GEN_CERT_FILE)
 
 # Basic metadata
 name = "nmos-auth"
-version = "1.0.11"
+version = "1.1.0"
 description = "OAuth2 Server Implementation"
 url = 'https://github.com/bbc/nmos-auth-server'
 author = 'Danny Meloy'

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 # Copyright 2019 British Broadcasting Corporation
 #

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,4 +1,4 @@
 [DEFAULT]
-Depends: python-six, python-authlib (>>0.10), python-cryptography (>=1.5), python-openssl (>=16.0), python-gevent, python-requests, python-werkzeug (>=0.13), python-flask, python-sqlalchemy, python-flask-sqlalchemy, python-flask-cors, python-nmoscommon, ips-reverseproxy-common
-Depends3: python3-six, python3-authlib (>>0.10), python3-cryptography (>=1.5), python3-openssl (>=16.0), python3-gevent, python3-requests, python3-werkzeug (>=0.13), python3-flask, python3-sqlalchemy, python3-flask-sqlalchemy, python3-flask-cors, python3-nmoscommon, python3-nmosreverseproxy
+Depends: python-six, python-authlib (>>0.10), python-cryptography, python-openssl, python-gevent, python-requests, python-werkzeug (>=0.13), python-flask, python-sqlalchemy, python-flask-sqlalchemy, python-flask-cors, python-nmoscommon, ips-reverseproxy-common
+Depends3: python3-six, python3-authlib (>>0.10), python3-cryptography, python3-openssl, python3-gevent, python3-requests, python3-werkzeug (>=0.13), python3-flask, python3-sqlalchemy, python3-flask-sqlalchemy, python3-flask-cors, python3-nmoscommon, python3-nmosreverseproxy
 Build-Depends: apache2-dev, dh-python, dh-systemd

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -138,8 +138,8 @@ class TestNmosAuth(unittest.TestCase):
             with self.client.post(VERSION_ROOT + '/register_client', data=register_data,
                                   headers=headers, follow_redirects=True) as rv:
                 self.assertEqual(rv.status_code, 201)
-                self.assertTrue('client_id' in rv.data)
-                self.assertTrue('client_secret' in rv.data)
+                self.assertTrue(b'client_id' in rv.data)
+                self.assertTrue(b'client_secret' in rv.data)
 
 
 if __name__ == '__main__':

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -133,6 +133,7 @@ class TestNmosAuth(unittest.TestCase):
             'token_endpoint_auth_method': 'client_secret_basic'
         }
         headers = self.auth_headers(self.mockUser)
+        print(headers)
         with mock.patch("nmosoauth.auth_server.security_api.session") as mock_session:
             mock_session.__getitem__.return_value = None
             with self.client.post(VERSION_ROOT + '/register_client', data=register_data,

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -22,10 +22,12 @@ from nmoscommon.logger import Logger
 from nmosauth.auth_server.db_utils import drop_all
 from nmosauth.auth_server.security_api import SecurityAPI
 from nmosauth.auth_server.security_api import User
-from nmos_auth_data import BEARER_TOKEN, TEST_PRIV_KEY
+from nmos_auth_data import TEST_PRIV_KEY
 from base64 import b64encode
 
 VERSION_ROOT = '/x-nmos/auth/v1.0'
+TEST_USERNAME = 'steve'
+TEST_PASSWORD = 'password'
 
 
 class TestNmosAuth(unittest.TestCase):
@@ -37,21 +39,24 @@ class TestNmosAuth(unittest.TestCase):
         self.app = self.api.app
         self.client = self.app.test_client()
 
-        self.mockUser = self.createMockUser("steve", "password")
+        self.user_id = 0
+        self.testUser = self.createUser(TEST_USERNAME, TEST_PASSWORD)
+        # Boilerplate for mocking out Basic Auth user for the whole class
         patcher = mock.patch("nmosauth.auth_server.basic_auth.User")
         self.mockBasicUser = patcher.start()
-        self.mockBasicUser.query.filter_by.return_value.first.return_value = self.mockUser
+        self.mockBasicUser.query.filter_by.return_value.first.return_value = self.testUser
         self.addCleanup(patcher.stop)
 
     def tearDown(self):
         with self.app.app_context():
             drop_all()
 
-    def createMockUser(self, username, password):
-        tempUser = User()
-        tempUser.username = username
-        tempUser.password = password
-        return tempUser
+    def createUser(self, username, password):
+        user = User()
+        user.username = username
+        user.password = password
+        user.id = self.user_id = self.user_id + 1
+        return user
 
     def auth_headers(self, user):
         auth_string = "{}:{}".format(user.username, user.password).encode('utf-8')
@@ -63,24 +68,28 @@ class TestNmosAuth(unittest.TestCase):
     def testGetInitialRoutes(self):
 
         with self.client as client:
+            # Correctly go to Home Page
             rv = client.get(VERSION_ROOT + '/', follow_redirects=True)
             self.assertEqual(rv.status_code, 200)
+            # Fetch Token redirects to login page
             rv = client.get(VERSION_ROOT + '/fetch_token/')
             self.assertEqual(rv.status_code, 302)
+            # Logout page redirects to login page
             rv = client.get(VERSION_ROOT + '/logout/')
             self.assertEqual(rv.status_code, 302)
 
     def testBasicAuthRoutes(self):
 
-        headers = self.auth_headers(self.mockUser)
+        headers = self.auth_headers(self.testUser)
         with self.client as client:
+            # Getting Register client redirects to login page
             rv = client.get(VERSION_ROOT + '/register_client/')
             self.assertEqual(rv.status_code, 302)
-
+            # Posting to Register client returns Basic Auth prompt
             rv = client.post(VERSION_ROOT + '/register_client')
             self.assertEqual(rv.status_code, 401)
-
-            wrongUser = self.createMockUser("bob", "pass")
+            # Posting to register client with incorrect credentials returns Unauthorized
+            wrongUser = self.createUser("bob", "pass")
             headers = self.auth_headers(wrongUser)
             rv = client.post(VERSION_ROOT + '/register_client', headers=headers)
             self.assertEqual(rv.status_code, 401)
@@ -90,51 +99,51 @@ class TestNmosAuth(unittest.TestCase):
     def testHome(self, mockUser, mockTemplate):
 
         mockTemplate.return_value = "test"
+        mockUser.query.filter_by.return_value.first.return_value = self.testUser
 
         with self.client.post(VERSION_ROOT + '/home/', data=dict(username="", password="")):
             mockTemplate.assert_called_with(
                 'home.html', clients=None, message='Please Fill In Both Username and Password.', user=None)
+
         with self.client.post(VERSION_ROOT + '/home/', data=dict(username="steve", password="wrongpassword")):
             mockTemplate.assert_called_with(
                 'home.html', clients=None, message='Invalid Password. Try Again.', user=None)
+
         with self.client.post(VERSION_ROOT + '/home/', data=dict(username="steve", password="password")) as rv:
-            self.assertEqual(rv.status_code, 200)
+            self.assertEqual(rv.status_code, 302)
+
         mockUser.query.filter_by.return_value.first.return_value = None
         with self.client.post(VERSION_ROOT + '/home/', data=dict(username="steve", password="password")):
             mockTemplate.assert_called_with(
                 'home.html', clients=None, message='That username is not recognised. Please signup.', user=None)
 
-    def testEndToEnd(self):
-
-        test_username = 'steve'
-        test_password = 'password'
+    def testRegisterClient(self):
 
         # SignUp
         signup_data = {
-            'username': test_username,
-            'password': test_password,
+            'username': TEST_USERNAME,
+            'password': TEST_PASSWORD,
             'is04': 'read',
             'is05': 'write'
         }
         with self.client.post(VERSION_ROOT + '/signup', data=signup_data) as rv:
             self.assertEqual(rv.status_code, 302)
             with self.app.app_context():
-                self.assertEqual(self.mockUser.username, User.query.get(1).username)
-                self.assertEqual(self.mockUser.password, User.query.get(1).password)
+                self.assertEqual(self.testUser.username, User.query.get(1).username)
+                self.assertEqual(self.testUser.password, User.query.get(1).password)
 
         # Register Client
         register_data = {
-            'client_name': 'R&D+Web+Router',
+            'client_name': 'R&D Web Router',
             'client_uri': 'http://ipstudio-master.rd.bbc.co.uk/ips-web/#/web-router',
-            'scope': 'is04+is05',
+            'scope': 'is04 is05',
             'redirect_uri': 'www.example.com',
             'grant_type': 'password',
             'response_type': 'code',
             'token_endpoint_auth_method': 'client_secret_basic'
         }
-        headers = self.auth_headers(self.mockUser)
-        print(headers)
-        with mock.patch("nmosoauth.auth_server.security_api.session") as mock_session:
+        headers = self.auth_headers(self.testUser)
+        with mock.patch("nmosauth.auth_server.security_api.session") as mock_session:
             mock_session.__getitem__.return_value = None
             with self.client.post(VERSION_ROOT + '/register_client', data=register_data,
                                   headers=headers, follow_redirects=True) as rv:


### PR DESCRIPTION
Minor version bump due to the number of changes:
- Change scripts to run on just python3 due to deprecation
- Move an env. var from the bin file into the service file (it appeared to flag an error even when using https??)
- Fix error when using the client credentials grant due to authlib returning user=None
- Add password checking when requesting a code using the auth code grant
- Change 'iss' claim to give FQDN of auth server
- Change 'aud' claim to give a generic return value based on the scope (this should be changed but is better than what we had)
- Unpinned deb dependencies as is useful to have the systemd and apache debhelpers when installing using ansible
- Pass auth code params in query string as opposed to body of request
- Merge a couple of unittests in for registering a user and an OAuth client
 