### PR TITLE
Create separate login page from Home Page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # NMOS Authorization API Implementation Changelog
 
+## 1.2.0
+- Add separate login_required decorator to decorate endpoints.
+
 ## 1.1.3
 - Add PKCE Support.
 

--- a/debian/python-nmos-auth.service
+++ b/debian/python-nmos-auth.service
@@ -8,7 +8,7 @@ Environment="AUTHLIB_INSECURE_TRANSPORT=1"
 User=ipstudio
 Restart=always
 RestartSec=3
-ExecStart=/usr/bin/nmosauth
+ExecStart=/usr/bin/python2 /usr/bin/nmosauth
 
 [Install]
 WantedBy=multi-user.target

--- a/nmosauth/auth_server/basic_auth.py
+++ b/nmosauth/auth_server/basic_auth.py
@@ -32,7 +32,16 @@ class BasicAuthorization():
             self.app = None
 
     def init_app(self, app):
+        self.app = app
         app.config.setdefault('BASIC_AUTH_REALM', '')
+        app.config.setdefault('BASIC_AUTH_FORCE', False)
+
+        @app.before_request
+        def require_basic_auth():
+            if not current_app.config['BASIC_AUTH_FORCE']:
+                return
+            if not self.authenticate():
+                return self.challenge()
 
     def check_credentials(self, username, password):
         try:

--- a/nmosauth/auth_server/handlers.py
+++ b/nmosauth/auth_server/handlers.py
@@ -33,7 +33,10 @@ def register_handlers(app):
     @app.errorhandler(401)
     def page_unauthorised(e):
         code = 401
-        return render_template('error.html', code=code, message="Unauthorised"), code
+        if "text/html" in request.headers.get("Accept"):
+            return render_template('error.html', code=code, message="Unauthorised"), code
+        else:
+            raise e
 
     @app.errorhandler(404)
     def page_not_found(e):
@@ -46,4 +49,7 @@ def register_handlers(app):
     @app.errorhandler(403)
     def page_forbiddon(e):
         code = 403
-        return render_template('error.html', code=code, message="Forbiddon"), code
+        if "text/html" in request.headers.get("Accept"):
+            return render_template('error.html', code=code, message="Forbiddon"), code
+        else:
+            raise e

--- a/nmosauth/auth_server/handlers.py
+++ b/nmosauth/auth_server/handlers.py
@@ -32,24 +32,18 @@ def register_handlers(app):
 
     @app.errorhandler(401)
     def page_unauthorised(e):
-        code = 401
-        if "text/html" in request.headers.get("Accept"):
-            return render_template('error.html', code=code, message="Unauthorised"), code
-        else:
-            raise e
+        return error_return(e, 401, "Unauthorised")
 
     @app.errorhandler(404)
     def page_not_found(e):
-        code = 404
-        if "text/html" in request.headers.get("Accept"):
-            return render_template('error.html', code=code, message="Not Found"), code
-        else:
-            raise e
+        return error_return(e, 404, "Page Not Found")
 
     @app.errorhandler(403)
     def page_forbiddon(e):
-        code = 403
-        if "text/html" in request.headers.get("Accept"):
-            return render_template('error.html', code=code, message="Forbiddon"), code
+        return error_return(e, 403, "Forbidden")
+
+    def error_return(e, code, message):
+        if "Accept" in request.headers and "text/html" in request.headers.get("Accept"):
+            return render_template('error.html', code=code, message=message), code
         else:
             raise e

--- a/nmosauth/auth_server/models.py
+++ b/nmosauth/auth_server/models.py
@@ -19,7 +19,6 @@ from authlib.flask.oauth2.sqla import (
     OAuth2AuthorizationCodeMixin,
     OAuth2TokenMixin,
 )
-from authlib.oauth2 import OAuth2Error
 
 __all__ = ['db', 'User', 'OAuth2Client',
            'OAuth2AuthorizationCode', 'OAuth2Token', 'AccessRights']
@@ -52,11 +51,6 @@ class OAuth2Client(db.Model, OAuth2ClientMixin):
     user_id = db.Column(
         db.Integer, db.ForeignKey('user.id', ondelete='CASCADE'))
     user = db.relationship('User')
-
-    def check_requested_scopes(self, scopes):  # Just for testing purposes
-        if len(set(scopes)) != 1:
-            raise OAuth2Error("Must list a single scope", None, 400)
-        return super(OAuth2Client, self).check_requested_scopes(scopes)
 
 
 class OAuth2AuthorizationCode(db.Model, OAuth2AuthorizationCodeMixin):

--- a/nmosauth/auth_server/security_api.py
+++ b/nmosauth/auth_server/security_api.py
@@ -69,7 +69,7 @@ class SecurityAPI(WebAPI):
                     abort(401)
             g.user = user
             if not user:
-                if "text/html" in request.headers.get("Accept"):
+                if "Accept" in request.headers and "text/html" in request.headers.get("Accept"):
                     session["redirect"] = request.url
                     return redirect(url_for('_login'))
                 else:

--- a/nmosauth/auth_server/security_api.py
+++ b/nmosauth/auth_server/security_api.py
@@ -110,12 +110,10 @@ class SecurityAPI(WebAPI):
             password = request.form.get('password')
             if not username or not password:
                 message = "Please Fill In Both Username and Password."
-                print(message)
                 return render_template('login.html', message=message)
             user = User.query.filter_by(username=username).first()
             if not user:
                 message = "That username is not recognised. Please signup."
-                print(message)
                 return render_template('login.html', message=message)
             if user.check_password(password):
                 session['id'] = user.id
@@ -125,7 +123,6 @@ class SecurityAPI(WebAPI):
                     return redirect(url_for('_home'))
             else:
                 message = "Invalid Password. Try Again."
-                print(message)
                 return render_template('login.html', message=message)
         return render_template('login.html')
 
@@ -156,7 +153,6 @@ class SecurityAPI(WebAPI):
         return redirect(url_for('_home'))
 
     @route(AUTH_VERSION_ROOT + 'signup/', methods=['GET'], auto_json=False)
-    @login_required
     def signup_get(self):
         return render_template('signup.html')
 
@@ -194,6 +190,7 @@ class SecurityAPI(WebAPI):
         return render_template('create_client.html')
 
     @route(AUTH_VERSION_ROOT + 'delete_client/<client_id>', auto_json=False)
+    @login_required
     def delete_client(self, client_id):
         removeClient(client_id)
         return redirect(url_for('_home'))
@@ -254,4 +251,4 @@ class SecurityAPI(WebAPI):
             del session['redirect']
         except Exception as e:
             self.logger.writeDebug("Error: {}. Couldn't delete session ID or Redirect string".format(str(e)))
-        return redirect(url_for('_home'))
+        return redirect(url_for('_login'))

--- a/nmosauth/auth_server/settings.py
+++ b/nmosauth/auth_server/settings.py
@@ -30,19 +30,20 @@ class BaseConfig(object):
     SQLALCHEMY_TRACK_MODIFICATIONS = False
     SQLALCHEMY_DATABASE_URI = 'sqlite:///{}/{}.sqlite'.format(NMOSAUTH_DIR, DATABASE_NAME)
     BASIC_AUTH_REALM = "NMOS Auth Server Login Required"
+    BASIC_AUTH_FORCE = False
     OAUTH2_ACCESS_TOKEN_GENERATOR = pkg + 'token_generator.gen_token'
     OAUTH2_REFRESH_TOKEN_GENERATOR = True
-    OAUTH2_TOKEN_EXPIRES_IN = {
-        'authorization_code': 60,
-        'implicit': 60,
-        'password': 60,
-        'client_credentials': 60
-    }
+    OAUTH2_JWT_EXP = 60
     OAUTH2_JWT_ENABLED = True
     OAUTH2_JWT_ISS = socket.getfqdn()
     OAUTH2_JWT_ALG = 'RS512'
-    OAUTH2_JWT_EXP = 60
     OAUTH2_JWT_KEY_PATH = PRIVKEY_PATH
+    OAUTH2_TOKEN_EXPIRES_IN = {
+        'authorization_code': OAUTH2_JWT_EXP,
+        'implicit': OAUTH2_JWT_EXP,
+        'password': OAUTH2_JWT_EXP,
+        'client_credentials': OAUTH2_JWT_EXP
+    }
 
 
 class TestConfig(BaseConfig):

--- a/nmosauth/auth_server/templates/create_client.html
+++ b/nmosauth/auth_server/templates/create_client.html
@@ -38,8 +38,11 @@ limitations under the License. -->
   </label>
   <label>
     <span>Allowed Grant Types:</span>
-    <textarea name="grant_type" cols="30" rows="10" placeholder="grant name">password
-authorization_code</textarea>
+    <textarea name="grant_type" cols="30" rows="10" placeholder="grant name">
+password
+authorization_code
+refresh_token
+    </textarea>
   </label>
   <label>
     <span>Allowed Response Types:</span>

--- a/nmosauth/auth_server/templates/home.html
+++ b/nmosauth/auth_server/templates/home.html
@@ -14,7 +14,6 @@ limitations under the License. -->
 
 {% extends "layout.html" %}
 {% block body %}
-  {% if user %}
     <div>
       <h2>Home</h2>
       <span>Logged in as <b>{{user.username}}</b> | <a href="{{ url_for('_logout') }}">Log Out</a></span>
@@ -56,16 +55,4 @@ limitations under the License. -->
       }
     </script>
 
-
-  {% else %}
-    <h2>Log In</h2>
-    <form action="" method="post">
-      <p><input type="text" name="username" placeholder="username"></p>
-      <p><input type="password" name="password"  placeholder="password"></p>
-      <button type="submit">Log-in</button>
-    </form>
-    <p><a class="button" href="{{ url_for('_signup_get') }}">Signup</a></p>
-  {% endif %}
-
-  <div><p>{{ message }}</p></div>
 {% endblock %}

--- a/nmosauth/auth_server/templates/login.html
+++ b/nmosauth/auth_server/templates/login.html
@@ -1,0 +1,29 @@
+<!-- Copyright 2019 British Broadcasting Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. -->
+
+{% extends "layout.html" %}
+{% block body %}
+
+<h2>Log In</h2>
+<form action="{{ url_for('_login') }}" method="post">
+  <p><input type="text" name="username" placeholder="username"></p>
+  <p><input type="password" name="password"  placeholder="password"></p>
+  <button type="submit">Log-in</button>
+</form>
+<p><a class="button" href="{{ url_for('_signup_get') }}">Signup</a></p>
+
+
+<div><p>{{ message }}</p></div>
+
+{% endblock %}

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ GEN_CERT_PATH = os.path.join(NMOSAUTH_DIR, GEN_CERT_FILE)
 
 # Basic metadata
 name = "nmos-auth"
-version = "1.1.3"
+version = "1.2.0"
 description = "OAuth2 Server Implementation"
 url = 'https://github.com/bbc/nmos-auth-server'
 author = 'Danny Meloy'


### PR DESCRIPTION
This PR includes:
- Unifies the way in which each route authenticates the user:
  - Looks in session storage for user id in the case of using the UI
  - Looks at Basic Auth headers if making HTTP requests (such as dynamic client registration)
  - Renders a 401 error code if valid user is not found or the login page if using a browser
- Removes coupling of the login page and the home page
- Removes restriction of one scope per token as multi-scope tokens are likely to be preferred
- Unifies all token expiry values for the various grant flows