### PR TITLE
Allow multiple "Resource Owners" per "OAuth Client"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # NMOS Authorization API Implementation Changelog
 
+## 1.3.0
+- Add Resource Owner database to allow one-to-many mapping between clients and end users. Add User page to UI.
+
 ## 1.2.0
 - Add separate login_required decorator to decorate endpoints.
 

--- a/nmosauth/auth_server/basic_auth.py
+++ b/nmosauth/auth_server/basic_auth.py
@@ -15,7 +15,7 @@
 from functools import wraps
 from flask import Response, request, current_app, render_template
 
-from .models import User
+from .models import AdminUser
 
 
 class BasicAuthorization():
@@ -45,7 +45,7 @@ class BasicAuthorization():
 
     def check_credentials(self, username, password):
         try:
-            user = User.query.filter_by(username=username).first()
+            user = AdminUser.query.filter_by(username=username).first()
             return username == user.username and password == user.password
         except Exception:
             return False

--- a/nmosauth/auth_server/db_utils.py
+++ b/nmosauth/auth_server/db_utils.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from six import string_types
-from .models import db, User, OAuth2Client, AccessRights
+from .models import db, AdminUser, OAuth2Client, ResourceOwner
 
 # -------------------- INIT ------------------------- #
 
@@ -40,15 +40,15 @@ def add(entry):
     db.session.commit()
 
 
-def addAccessRights(user, IS04Access, IS05Access):
-    access = AccessRights(user_id=user.id, is04=IS04Access, is05=IS05Access)
+def addResourceOwner(user, username, password, is04_access, is05_access):
+    access = ResourceOwner(user_id=user.id, username=username, password=password, is04=is04_access, is05=is05_access)
     add(access)
     return access
 
 
-def addUser(username, password):
-    if User.query.filter_by(username=username).scalar() is None:
-        user = User(username=username, password=password)
+def addAdminUser(username, password):
+    if AdminUser.query.filter_by(username=username).scalar() is None:
+        user = AdminUser(username=username, password=password)
         add(user)
         return user
 
@@ -74,12 +74,23 @@ def printField(table, field):
     return eval(s)
 
 
-def getUser(user):
+def getAdminUser(user):
     try:
         if isinstance(user, int):
-            entry = User.query.get_or_404(user)
+            entry = AdminUser.query.get_or_404(user)
         elif isinstance(user, string_types):
-            entry = User.query.filter_by(username=user).first_or_404()
+            entry = AdminUser.query.filter_by(username=user).first_or_404()
+        return entry
+    except Exception:
+        return None
+
+
+def getResourceOwner(user):
+    try:
+        if isinstance(user, int):
+            entry = ResourceOwner.query.get_or_404(user)
+        elif isinstance(user, string_types):
+            entry = ResourceOwner.query.filter_by(username=user).first_or_404()
         return entry
     except Exception:
         return None
@@ -114,20 +125,37 @@ def remove(entry):
     db.session.commit()
 
 
-def removeUser(user):
-    if isinstance(user, int):
-        entry = User.query.get_or_404(user)
-    elif isinstance(user, string_types):
-        entry = User.query.filter_by(username=user).first_or_404()
-    remove(entry)
+def removeAdminUser(user):
+    try:
+        if isinstance(user, int):
+            entry = AdminUser.query.get_or_404(user)
+        elif isinstance(user, string_types):
+            entry = AdminUser.query.filter_by(username=user).first_or_404()
+            remove(entry)
+    except Exception:
+        return None
+
+
+def removeResourceOwner(user):
+    try:
+        if isinstance(user, int):
+            entry = ResourceOwner.query.get_or_404(user)
+        elif isinstance(user, string_types):
+            entry = ResourceOwner.query.filter_by(username=user).first_or_404()
+            remove(entry)
+    except Exception:
+        return None
 
 
 def removeClient(client_id):
-    if isinstance(client_id, int):
-        entry = OAuth2Client.query.get_or_404(client_id)
-    else:
-        entry = OAuth2Client.query.filter_by(client_id=client_id).first_or_404()
-    remove(entry)
+    try:
+        if isinstance(client_id, int):
+            entry = OAuth2Client.query.get_or_404(client_id)
+        else:
+            entry = OAuth2Client.query.filter_by(client_id=client_id).first_or_404()
+        remove(entry)
+    except Exception:
+        return None
 
 
 def removeAll(table):  # To clear token data

--- a/nmosauth/auth_server/models.py
+++ b/nmosauth/auth_server/models.py
@@ -86,7 +86,7 @@ class ResourceOwner(db.Model):
         db.Integer, db.ForeignKey('admin_user.id', ondelete='CASCADE'))
     admin_user = db.relationship('AdminUser')
 
-    username = db.Column(db.String(40), unique=True)
+    username = db.Column(db.String(40), unique=True, nullable=False)
     password = db.Column(db.String(20))
     is04 = db.Column(db.String(25))
     is05 = db.Column(db.String(25))

--- a/nmosauth/auth_server/models.py
+++ b/nmosauth/auth_server/models.py
@@ -34,7 +34,7 @@ class AdminUser(db.Model):
     def __str__(self):
         output = ''
         for c in self.__table__.columns:
-            output += '{}: {},  '.format(c.name, getattr(self, c.name))
+            output[c.name] = getattr(self, c.name)
         return output
 
     def get_user_id(self):
@@ -98,7 +98,7 @@ class ResourceOwner(db.Model):
         return password == self.password
 
     def __str__(self):
-        output = ''
+        output = {}
         for c in self.__table__.columns:
-            output += '{}: {},  '.format(c.name, getattr(self, c.name))
+            output[c.name] = getattr(self, c.name)
         return output

--- a/nmosauth/auth_server/oauth2.py
+++ b/nmosauth/auth_server/oauth2.py
@@ -24,7 +24,8 @@ from authlib.oauth2.rfc6749.errors import InvalidRequestError
 from authlib.oauth2.rfc7636 import CodeChallenge
 from werkzeug.security import gen_salt
 
-from .models import db, User, OAuth2Client, OAuth2AuthorizationCode, OAuth2Token
+from .models import db, OAuth2Client, OAuth2AuthorizationCode, OAuth2Token
+from .db_utils import getResourceOwner
 
 
 class AuthorizationCodeGrant(grants.AuthorizationCodeGrant):
@@ -56,12 +57,12 @@ class AuthorizationCodeGrant(grants.AuthorizationCodeGrant):
         db.session.commit()
 
     def authenticate_user(self, authorization_code):
-        return User.query.get(authorization_code.user_id)
+        return getResourceOwner(authorization_code.user_id)
 
 
 class PasswordGrant(grants.ResourceOwnerPasswordCredentialsGrant):
     def authenticate_user(self, username, password):
-        user = User.query.filter_by(username=username).first()
+        user = getResourceOwner(username)
         if user is None:
             raise InvalidRequestError("User Not Found")
         if user.check_password(password):
@@ -75,7 +76,7 @@ class RefreshTokenGrant(grants.RefreshTokenGrant):
             return item
 
     def authenticate_user(self, credential):
-        return User.query.get(credential.user_id)
+        return getResourceOwner(credential.user_id)
 
 
 query_client = create_query_client_func(db.session, OAuth2Client)

--- a/nmosauth/auth_server/security_api.py
+++ b/nmosauth/auth_server/security_api.py
@@ -274,7 +274,10 @@ class SecurityAPI(WebAPI):
         password = request.form.get("password")
         is04 = request.form.get("is04")
         is05 = request.form.get("is05")
-        addResourceOwner(user, username, password, is04, is05)
+        if any(i in [None, ''] for i in (user, username, password)):
+            return redirect(url_for('_get_users'))
+        else:
+            addResourceOwner(user, username, password, is04, is05)
         return redirect(url_for('_get_users'))
 
     @route(AUTH_VERSION_ROOT + 'users/<username>', methods=['GET'], auto_json=False)

--- a/nmosauth/auth_server/security_api.py
+++ b/nmosauth/auth_server/security_api.py
@@ -261,6 +261,7 @@ class SecurityAPI(WebAPI):
         return render_template('users.html', user=user, owners=resource_owners)
 
     @route(AUTH_VERSION_ROOT + 'add_user', methods=['POST'], auto_json=False)
+    @admin_required
     def add_user(self):
         user = getAdminUser(session['id'])
         username = request.form.get("username")
@@ -271,6 +272,7 @@ class SecurityAPI(WebAPI):
         return redirect(url_for('_get_users'))
 
     @route(AUTH_VERSION_ROOT + 'users/<username>', methods=['GET'], auto_json=False)
+    @admin_required
     def delete_user(self, username):
         removeResourceOwner(username)
         return redirect(url_for('_get_users'))

--- a/nmosauth/auth_server/security_api.py
+++ b/nmosauth/auth_server/security_api.py
@@ -88,9 +88,9 @@ class SecurityAPI(WebAPI):
                 owner = getResourceOwner(username)
                 if not owner or not owner.check_password(request.authorization.password):
                     abort(401)
-            g.owner = owner
             if not owner:
                 if "Accept" in request.headers and "text/html" in request.headers.get("Accept"):
+                    session["owner"] = True
                     session["redirect"] = request.url
                     return redirect(url_for('_login'))
                 else:
@@ -134,8 +134,9 @@ class SecurityAPI(WebAPI):
             if not username or not password:
                 message = "Please Fill In Both Username and Password."
                 return render_template('login.html', message=message)
-            if "owner" in g:
+            if "owner" in session and session["owner"] is True:
                 user = getResourceOwner(username)
+                del session["owner"]
             else:
                 user = getAdminUser(username)
             if not user:

--- a/nmosauth/auth_server/security_api.py
+++ b/nmosauth/auth_server/security_api.py
@@ -22,10 +22,10 @@ from authlib.oauth2.rfc6749 import OAuth2Error, InvalidRequestError
 from nmoscommon.webapi import WebAPI, route
 from nmoscommon.auth.nmos_auth import RequiresAuth
 
-from .models import db, User, OAuth2Client
+from .models import db, AdminUser, OAuth2Client, ResourceOwner
 from .oauth2 import authorization
 from .app import config_app
-from .db_utils import getUser, removeClient, addUser, addAccessRights
+from .db_utils import getAdminUser, removeClient, addAdminUser, addResourceOwner, getResourceOwner
 from .constants import CERT_PATH
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -55,20 +55,40 @@ class SecurityAPI(WebAPI):
         ])
         self.app.jinja_loader = my_loader
 
-    def login_required(view_func):
+    def admin_required(view_func):
         @wraps(view_func)
         def wrapper(*args, **kwargs):
             user = None
             if 'id' in session:
                 uid = session['id']
-                user = getUser(uid)
+                user = getAdminUser(uid)
             elif request.authorization:
                 username = request.authorization.username
-                user = getUser(username)
+                user = getAdminUser(username)
                 if not user or not user.check_password(request.authorization.password):
                     abort(401)
             g.user = user
             if not user:
+                if "Accept" in request.headers and "text/html" in request.headers.get("Accept"):
+                    session["redirect"] = request.url
+                    return redirect(url_for('_login'))
+                else:
+                    abort(401)
+            else:
+                return view_func(*args, **kwargs)
+        return wrapper
+
+    def owner_required(view_func):
+        @wraps(view_func)
+        def wrapper(*args, **kwargs):
+            owner = None
+            if request.authorization:
+                username = request.authorization.username
+                owner = getResourceOwner(username)
+                if not owner or not owner.check_password(request.authorization.password):
+                    abort(401)
+            g.owner = owner
+            if not owner:
                 if "Accept" in request.headers and "text/html" in request.headers.get("Accept"):
                     session["redirect"] = request.url
                     return redirect(url_for('_login'))
@@ -113,7 +133,10 @@ class SecurityAPI(WebAPI):
             if not username or not password:
                 message = "Please Fill In Both Username and Password."
                 return render_template('login.html', message=message)
-            user = User.query.filter_by(username=username).first()
+            if "owner" in g:
+                user = getResourceOwner(username)
+            else:
+                user = getAdminUser(username)
             if not user:
                 message = "That username is not recognised. Please signup."
                 return render_template('login.html', message=message)
@@ -129,7 +152,7 @@ class SecurityAPI(WebAPI):
         return render_template('login.html')
 
     @route(AUTH_VERSION_ROOT + 'home/', methods=['GET'], auto_json=False)
-    @login_required
+    @admin_required
     def home(self):
         user = g.user
         if user:
@@ -144,13 +167,11 @@ class SecurityAPI(WebAPI):
         password = request.form.get('password', None)
         if not username or not password:
             return redirect(url_for('_signup_get'))
-        user = addUser(username, password)
+        user = addAdminUser(username, password)
         if user is None:
             return render_template('signup.html', message="Invalid Username. Please choose another one.")
-        is04 = request.form.get('is04', None)
-        is05 = request.form.get('is05', None)
-        addAccessRights(user, is04, is05)
-
+        # Create Resource Owner account for Admin with full Write privileges
+        addResourceOwner(user, username=username, password=password, is04_access="write", is05_access="write")
         session['id'] = user.id
         return redirect(url_for('_home'))
 
@@ -159,7 +180,7 @@ class SecurityAPI(WebAPI):
         return render_template('signup.html')
 
     @route(AUTH_VERSION_ROOT + 'register_client', methods=['POST'], auto_json=False)
-    @login_required
+    @admin_required
     def create_client_post(self):
         user = g.user
         if request.headers["Content-Type"] == "application/json":
@@ -184,18 +205,18 @@ class SecurityAPI(WebAPI):
             return jsonify(client_info), 201
 
     @route(AUTH_VERSION_ROOT + 'register_client/', methods=['GET'], auto_json=False)
-    @login_required
+    @admin_required
     def create_client_get(self):
         return render_template('create_client.html')
 
     @route(AUTH_VERSION_ROOT + 'delete_client/<client_id>', auto_json=False)
-    @login_required
+    @admin_required
     def delete_client(self, client_id):
         removeClient(client_id)
         return redirect(url_for('_home'))
 
     @route(AUTH_VERSION_ROOT + 'fetch_token/', auto_json=False)
-    @login_required
+    @admin_required
     def fetch_token(self):
         user = g.user
         # TODO - drop-down select box
@@ -203,7 +224,7 @@ class SecurityAPI(WebAPI):
         return render_template('fetch_token.html', client=client)
 
     @route(AUTH_VERSION_ROOT + 'authorize', methods=['POST'], auto_json=False)
-    @login_required
+    @owner_required
     def authorization_post(self):
         user = g.user
         if "confirm" in request.form.keys() and request.form['confirm'] == "true":
@@ -213,7 +234,7 @@ class SecurityAPI(WebAPI):
         return authorization.create_authorization_response(grant_user=grant_user)
 
     @route(AUTH_VERSION_ROOT + 'authorize/', methods=['GET'], auto_json=False)
-    @login_required
+    @owner_required
     def authorization_get(self):
         user = g.user
         try:

--- a/nmosauth/auth_server/static/main.js
+++ b/nmosauth/auth_server/static/main.js
@@ -83,3 +83,16 @@ $(function getResource() {
     });
   });
 });
+
+var collapsibles = document.getElementsByClassName("collapsible");
+Object.values(collapsibles).forEach(function(collapsible) {
+  collapsible.addEventListener("click", function() {
+    collapsible.classList.toggle("active");
+    var content = collapsible.nextElementSibling
+    if (content.style.maxHeight) {
+      content.style.maxHeight = null
+    } else {
+      content.style.maxHeight = content.scrollHeight + "px";
+    }
+  })
+})

--- a/nmosauth/auth_server/static/style.css
+++ b/nmosauth/auth_server/static/style.css
@@ -160,3 +160,10 @@ input, textarea, select {
   transition: max-height 0.5s ease-out;
   background-color: #f1f1f1;
 }
+
+.title {
+  font-size: x-large;
+  color: #777;
+  background-color: #f1f1f1;
+  text-decoration: underline;
+}

--- a/nmosauth/auth_server/templates/error.html
+++ b/nmosauth/auth_server/templates/error.html
@@ -17,7 +17,7 @@ limitations under the License. -->
 <head>
   <title>BBC R&amp;D OAuth2 Server</title>
   <link rel="stylesheet" type="text/css" href="{{ url_for('_style', filename='error.css') }}">
-  <link rel="icon" href="http://newsvote.bbc.co.uk/favicon.ico">
+  <link rel="icon" href="{{ url_for('_style', filename='bbc_favicon.ico') }}">
 </head>
 
 <h1>{{ code }} Error Page: {{ message }}</h1>

--- a/nmosauth/auth_server/templates/fetch_token.html
+++ b/nmosauth/auth_server/templates/fetch_token.html
@@ -14,7 +14,6 @@ limitations under the License. -->
 
 {% extends "layout.html" %}
 {% block body %}
-<script src="{{ url_for('_style', filename='main.js') }}"></script>
 
 <h2>Fetch Token</h2>
 

--- a/nmosauth/auth_server/templates/home.html
+++ b/nmosauth/auth_server/templates/home.html
@@ -39,20 +39,19 @@ limitations under the License. -->
     {% endfor %}
 
     <script>
-      var coll = document.getElementsByClassName("collapsible");
-      var i;
+      var collapsibles = document.getElementsByClassName("collapsible");
 
-      for (i = 0; i < coll.length; i++) {
-        coll[i].addEventListener("click", function() {
-          this.classList.toggle("active");
-          var content = this.nextElementSibling;
+      Object.values(collapsibles).forEach(function(collapsible) {
+        collapsible.addEventListener("click", function() {
+          collapsible.classList.toggle("active");
+          var content = collapsible.nextElementSibling
           if (content.style.maxHeight) {
-            content.style.maxHeight = null;
+            content.style.maxHeight = null
           } else {
             content.style.maxHeight = content.scrollHeight + "px";
           }
-        });
-      }
+        })
+      })
     </script>
 
 {% endblock %}

--- a/nmosauth/auth_server/templates/home.html
+++ b/nmosauth/auth_server/templates/home.html
@@ -38,20 +38,4 @@ limitations under the License. -->
       </div><br>
     {% endfor %}
 
-    <script>
-      var collapsibles = document.getElementsByClassName("collapsible");
-
-      Object.values(collapsibles).forEach(function(collapsible) {
-        collapsible.addEventListener("click", function() {
-          collapsible.classList.toggle("active");
-          var content = collapsible.nextElementSibling
-          if (content.style.maxHeight) {
-            content.style.maxHeight = null
-          } else {
-            content.style.maxHeight = content.scrollHeight + "px";
-          }
-        })
-      })
-    </script>
-
 {% endblock %}

--- a/nmosauth/auth_server/templates/layout.html
+++ b/nmosauth/auth_server/templates/layout.html
@@ -28,16 +28,13 @@ limitations under the License. -->
       <a href="{{ url_for('_get_cert') }}">Certificates</a>
       <a href="{{ url_for('_get_users') }}">Users</a>
     </div>
-    <script>
-      window.jQuery || document.write(
-        '<script src="{{ url_for('_style', filename='jquery.js') }}">\x3C/script>'
-      )
-    </script>
-      <script type="text/javascript">
-        $SCRIPT_ROOT = {{ request.script_root|tojson|safe }};
-      </script>
     <div class="page">
       {% block body %}{% endblock %}
     </div>
+    <script type="text/javascript">
+      $SCRIPT_ROOT = {{ request.script_root|tojson|safe }};
+    </script>
+    <script src="{{ url_for('_style', filename='jquery.js') }}"></script>
+    <script src="{{ url_for('_style', filename='main.js') }}"></script>
   </body>
 </html>

--- a/nmosauth/auth_server/templates/layout.html
+++ b/nmosauth/auth_server/templates/layout.html
@@ -26,6 +26,7 @@ limitations under the License. -->
       <a href="{{ url_for('_create_client_get') }}">Register Client</a>
       <a href="{{ url_for('_fetch_token') }}">Request Token</a>
       <a href="{{ url_for('_get_cert') }}">Certificates</a>
+      <a href="{{ url_for('_get_users') }}">Users</a>
     </div>
     <script>
       window.jQuery || document.write(

--- a/nmosauth/auth_server/templates/signup.html
+++ b/nmosauth/auth_server/templates/signup.html
@@ -26,21 +26,6 @@ limitations under the License. -->
     <span>Password:</span>
     <input type="text" name="password" id="password" placeholder="password"><br>
   </label>
-  <label>
-    <span>IS-04 Access Rights:</span>
-    <select name="is04" id="is04">
-      <option value="read">Read</option>
-      <option value="write">Write</option>
-    </select>
-  </label>
-  <label>
-    <span>IS-05 Access Rights:</span>
-    <select name="is05" id="is05">
-      <option value="read">Read</option>
-      <option value="write">Write</option>
-    </select>
-    <br>
-  </label>
   <button type="submit">Signup</button>
 </form>
 

--- a/nmosauth/auth_server/templates/users.html
+++ b/nmosauth/auth_server/templates/users.html
@@ -41,7 +41,7 @@ limitations under the License. -->
       </select>
       <br>
     </label>
-    <button type="submit">Signup</button>
+    <button type="submit">Add User</button>
   </form>
 </div>
 <br>
@@ -59,21 +59,5 @@ limitations under the License. -->
     <p>IS-05 Access Rights: {{ owner.is05 }}</p>
   </div><br>
 {% endfor %}
-
-<script>
-  var collapsibles = document.getElementsByClassName("collapsible");
-
-  Object.values(collapsibles).forEach(function(collapsible) {
-    collapsible.addEventListener("click", function() {
-      collapsible.classList.toggle("active");
-      var content = collapsible.nextElementSibling
-      if (content.style.maxHeight) {
-        content.style.maxHeight = null
-      } else {
-        content.style.maxHeight = content.scrollHeight + "px";
-      }
-    })
-  })
-</script>
 
 {% endblock %}

--- a/nmosauth/auth_server/templates/users.html
+++ b/nmosauth/auth_server/templates/users.html
@@ -1,0 +1,78 @@
+<!-- Copyright 2019 British Broadcasting Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. -->
+
+{% extends "layout.html" %}
+{% block body %}
+
+<button class="collapsible"><b>Add User</b></button>
+<div class="content">
+  <form action="{{ url_for('_add_user') }}" method="post">
+    <label>
+      <span>Username:</span>
+      <input type="text" name="username" id="username" placeholder="Joe Bloggs"><br>
+    </label>
+    <label>
+      <span>Password:</span>
+      <input type="text" name="password" id="password" placeholder="password"><br>
+    </label>
+    <label>
+      <span>IS-04 Access Rights:</span>
+      <select name="is04" id="is04">
+        <option value="read">Read</option>
+        <option value="write">Write</option>
+      </select>
+    </label>
+    <label>
+      <span>IS-05 Access Rights:</span>
+      <select name="is05" id="is05">
+        <option value="read">Read</option>
+        <option value="write">Write</option>
+      </select>
+      <br>
+    </label>
+    <button type="submit">Signup</button>
+  </form>
+</div>
+<br>
+
+{% for owner in owners %}
+<button class="collapsible"><b>Owner {{ loop.index }} - {{ owner.username }}</b>
+  <sup>
+    <a href="{{ url_for('_delete_user', username=owner.username) }}">delete</a>
+  </sup>
+</button>
+  <div class="content">
+    Username: {{ owner.username }}<br>
+    IS-04: Access Rights: {{ owner.is04 }}<br>
+    IS-05: Access Rights: {{ owner.is05 }}
+  </div><br>
+{% endfor %}
+
+<script>
+  var collapsibles = document.getElementsByClassName("collapsible");
+
+  Object.values(collapsibles).forEach(function(collapsible) {
+    collapsible.addEventListener("click", function() {
+      collapsible.classList.toggle("active");
+      var content = collapsible.nextElementSibling
+      if (content.style.maxHeight) {
+        content.style.maxHeight = null
+      } else {
+        content.style.maxHeight = content.scrollHeight + "px";
+      }
+    })
+  })
+</script>
+
+{% endblock %}

--- a/nmosauth/auth_server/templates/users.html
+++ b/nmosauth/auth_server/templates/users.html
@@ -15,7 +15,7 @@ limitations under the License. -->
 {% extends "layout.html" %}
 {% block body %}
 
-<button class="collapsible"><b>Add User</b></button>
+<button class="collapsible title"><b>Add User</b></button>
 <div class="content">
   <form action="{{ url_for('_add_user') }}" method="post">
     <label>
@@ -53,9 +53,10 @@ limitations under the License. -->
   </sup>
 </button>
   <div class="content">
-    Username: {{ owner.username }}<br>
-    IS-04: Access Rights: {{ owner.is04 }}<br>
-    IS-05: Access Rights: {{ owner.is05 }}
+    <p>Username: {{ owner.username }}</p>
+    <p>Password: {{ owner.password }}</p>
+    <p>IS-04 Access Rights: {{ owner.is04 }}</p>
+    <p>IS-05 Access Rights: {{ owner.is05 }}</p>
   </div><br>
 {% endfor %}
 

--- a/nmosauth/auth_server/token_generator.py
+++ b/nmosauth/auth_server/token_generator.py
@@ -30,11 +30,9 @@ class TokenGenerator():
             return "client_credentials"
         else:
             if scope == "is-04":
-                user_access = ResourceOwner.query.filter_by(user_id=user.id).first()
-                access = user_access.is04
+                access = user.is04
             elif scope == "is-05":
-                user_access = ResourceOwner.query.filter_by(user_id=user.id).first()
-                access = user_access.is05
+                access = user.is05
             else:
                 access = None
             return access

--- a/nmosauth/auth_server/token_generator.py
+++ b/nmosauth/auth_server/token_generator.py
@@ -16,7 +16,7 @@ import os
 from authlib.jose import jwt
 import datetime
 from .oauth2 import authorization
-from .models import AccessRights
+from .models import ResourceOwner
 from .constants import NMOSAUTH_DIR, PRIVKEY_FILE
 
 
@@ -30,10 +30,10 @@ class TokenGenerator():
             return "client_credentials"
         else:
             if scope == "is-04":
-                user_access = AccessRights.query.filter_by(user_id=user.id).first()
+                user_access = ResourceOwner.query.filter_by(user_id=user.id).first()
                 access = user_access.is04
             elif scope == "is-05":
-                user_access = AccessRights.query.filter_by(user_id=user.id).first()
+                user_access = ResourceOwner.query.filter_by(user_id=user.id).first()
                 access = user_access.is05
             else:
                 access = None

--- a/nmosauth/auth_server/token_generator.py
+++ b/nmosauth/auth_server/token_generator.py
@@ -16,7 +16,6 @@ import os
 from authlib.jose import jwt
 import datetime
 from .oauth2 import authorization
-from .models import ResourceOwner
 from .constants import NMOSAUTH_DIR, PRIVKEY_FILE
 
 

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ GEN_CERT_PATH = os.path.join(NMOSAUTH_DIR, GEN_CERT_FILE)
 
 # Basic metadata
 name = "nmos-auth"
-version = "1.2.0"
+version = "1.3.0"
 description = "OAuth2 Server Implementation"
 url = 'https://github.com/bbc/nmos-auth-server'
 author = 'Danny Meloy'

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -20,8 +20,8 @@ from werkzeug.exceptions import HTTPException
 
 from nmoscommon.logger import Logger
 from nmosauth.auth_server.db_utils import drop_all
+from nmosauth.auth_server.models import AdminUser
 from nmosauth.auth_server.security_api import SecurityAPI
-from nmosauth.auth_server.security_api import User
 from nmos_auth_data import TEST_PRIV_KEY
 from base64 import b64encode
 
@@ -30,7 +30,7 @@ TEST_USERNAME = 'steve'
 TEST_PASSWORD = 'password'
 
 
-class TestNmosAuth(unittest.TestCase):
+class TestNmosAuthServer(unittest.TestCase):
 
     def setUp(self):
         self.api = SecurityAPI(logger=Logger("testing"), nmosConfig=None,
@@ -42,7 +42,7 @@ class TestNmosAuth(unittest.TestCase):
         self.user_id = 0
         self.testUser = self.createUser(TEST_USERNAME, TEST_PASSWORD)
         # Boilerplate for mocking out Basic Auth user for the whole class
-        patcher = mock.patch("nmosauth.auth_server.basic_auth.User")
+        patcher = mock.patch("nmosauth.auth_server.basic_auth.AdminUser")
         self.mockBasicUser = patcher.start()
         self.mockBasicUser.query.filter_by.return_value.first.return_value = self.testUser
         self.addCleanup(patcher.stop)
@@ -52,7 +52,7 @@ class TestNmosAuth(unittest.TestCase):
             drop_all()
 
     def createUser(self, username, password):
-        user = User()
+        user = AdminUser()
         user.username = username
         user.password = password
         user.id = self.user_id = self.user_id + 1
@@ -85,18 +85,18 @@ class TestNmosAuth(unittest.TestCase):
                 rv = client.post(VERSION_ROOT + '/authorize')
                 self.assertEqual(http_error.exception.code, 401)
 
-    @mock.patch("nmosauth.auth_server.security_api.getUser")
-    def testBasicAuthRoutes(self, mockGetUser):
+    @mock.patch("nmosauth.auth_server.security_api.getAdminUser")
+    def testBasicAuthRoutes(self, mockGetAdminUser):
 
-        mockGetUser.return_value = self.testUser
+        mockGetAdminUser.return_value = self.testUser
         headers = self.auth_headers(self.testUser)
         with self.client as client:
-            # Posting to Register client returns 200 status code
+            # Get /register_client returns 200 status code
             rv = client.get(VERSION_ROOT + '/register_client/', headers=headers)
             self.assertEqual(rv.status_code, 200)
-            mockGetUser.assert_called_with(self.testUser.username)
+            mockGetAdminUser.assert_called_with(self.testUser.username)
 
-            # Posting to register client with incorrect credentials returns Unauthorized
+            # Get /register_client with incorrect credentials returns Unauthorized
             wrongUser = self.createUser("bob", "pass")
             headers = self.auth_headers(wrongUser)
             with self.assertRaises(HTTPException) as http_error:
@@ -104,11 +104,11 @@ class TestNmosAuth(unittest.TestCase):
                 self.assertEqual(http_error.exception.code, 401)
 
     @mock.patch("nmosauth.auth_server.security_api.render_template")
-    @mock.patch("nmosauth.auth_server.security_api.User")
-    def testLogin(self, mockUser, mockTemplate):
+    @mock.patch("nmosauth.auth_server.security_api.getAdminUser")
+    def testLogin(self, mockGetAdminUser, mockTemplate):
 
         mockTemplate.return_value = "test"
-        mockUser.query.filter_by.return_value.first.return_value = self.testUser
+        mockGetAdminUser.return_value = self.testUser
 
         with self.client.post(VERSION_ROOT + '/login/', data=dict(username="", password="")):
             mockTemplate.assert_called_with(
@@ -121,7 +121,7 @@ class TestNmosAuth(unittest.TestCase):
         with self.client.post(VERSION_ROOT + '/login/', data=dict(username="steve", password="password")) as rv:
             self.assertEqual(rv.status_code, 302)
 
-        mockUser.query.filter_by.return_value.first.return_value = None
+        mockGetAdminUser.return_value = None
         with self.client.post(VERSION_ROOT + '/login/', data=dict(username="steve", password="password")):
             mockTemplate.assert_called_with(
                 'login.html', message='That username is not recognised. Please signup.')
@@ -138,8 +138,8 @@ class TestNmosAuth(unittest.TestCase):
         with self.client.post(VERSION_ROOT + '/signup', data=signup_data) as rv:
             self.assertEqual(rv.status_code, 302)
             with self.app.app_context():
-                self.assertEqual(self.testUser.username, User.query.get(1).username)
-                self.assertEqual(self.testUser.password, User.query.get(1).password)
+                self.assertEqual(self.testUser.username, AdminUser.query.get(1).username)
+                self.assertEqual(self.testUser.password, AdminUser.query.get(1).password)
 
         # Register Client
         register_data = {


### PR DESCRIPTION
The limitation of the Auth Server thus far has been that each client was associated with a single user. This meant that each user/resource owner would have to use the same user credentials when using a specific client. This PR:
- Adds a database `ResourceOwner` to store a list of users associated with a given `Admin User`
- Adds a separate page to facilitate the adding and deleting of users for the AdminUser that is currently logged in.
- Has altered the `authenticate_user` functions for each grant type to use the `ResourceOwner` database instead of the `AdminUsers` database.
