### PR TITLE
Change from /certs endpoint to serving JSON Web Keys at /jwks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # NMOS Authorization API Implementation Changelog
 
+## 1.3.4
+- Change from /certs endpoint to serving JSON Web Keys at /jwks
+
 ## 1.3.3
 - Use Python script to generate certs during debian install.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # NMOS Authorization API Implementation Changelog
 
 ## 1.3.4
-- Change from /certs endpoint to serving JSON Web Keys at /jwks
+- Change from /certs endpoint to serving JSON Web Keys at /jwks.
+  Host server metadata endpoint at `/.well-known/oauth-authorization-server`.
 
 ## 1.3.3
 - Use Python script to generate certs during debian install.

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ test:
 	tox
 
 deb_dist: $(topbuilddir)/dist/$(MODNAME)-$(VERSION).tar.gz
-	$(PY2DSC) --with-python2=true --with-python3=true $(topbuilddir)/dist/$(MODNAME)-$(VERSION).tar.gz
+	$(PY2DSC) --with-python3=true $(topbuilddir)/dist/$(MODNAME)-$(VERSION).tar.gz
 	sed -i 's/--with/--with apache2 --with systemd --with/' deb_dist/$(DEBNAME)-$(DEBVERSION)/debian/rules
 
 $(DEBIANDIR)/%: $(topdir)/debian/% deb_dist

--- a/debian/ips-api-auth.conf
+++ b/debian/ips-api-auth.conf
@@ -3,3 +3,9 @@
     ProxyPass http://127.0.0.1:4999/x-nmos/auth timeout=10 connectiontimeout=1 max=10 ttl=1 smax=10 retry=0
     ProxyPassReverse http://127.0.0.1:4999/x-nmos/auth
 </Location>
+
+<Location /.well-known/oauth-authorization-server>
+    ProxyPreserveHost On
+    ProxyPass http://127.0.0.1:4999/.well-known/oauth-authorization-server timeout=10 connectiontimeout=1 max=10 ttl=1 smax=10 retry=0
+    ProxyPassReverse http://127.0.0.1:4999/.well-known/oauth-authorization-server
+</Location>

--- a/nmosauth/README.md
+++ b/nmosauth/README.md
@@ -63,19 +63,20 @@ The file structure of the auth server is:
 ```
 auth_server/
   app.py              --- Flask App Configuration Loader
+  basic_auth.py       --- Basic Auth Setup
+  config.py           --- NMOS specific configuration
+  db_utils            --- Database Utility Funcs
+  handlers.py         --- error handlers
   models.py           --- SQLAlchemy Models
   oauth2.py           --- OAuth 2.0 Provider Configuration
   security_api.py     --- Routes views
   security_service.py --- HTTP Server and mdns registration
-  token_generator.py  --- Token Generator class
-  handlers.py         --- error handlers
   settings.py         --- Flask Configuration classes
-  basic_auth.py       --- Basic Auth Setup
-  db_utils            --- Database Utility Funcs
+  token_generator.py  --- Token Generator class
   templates/          --- static content (*.html)
   static/             --- static content (*.js, *.css)
 certs/
-  generate_cert.sh    --- Cert and Key generation script
+  gen_cert.py         --- Cert and Key generation script
 ```
 
 ## Define Models
@@ -127,5 +128,5 @@ For a full list of endpoints please see `auth_server/security_api.py`. A prefix 
 * */token* - for requesting a token
 * */signup* - for adding a user
 * */register_client* - creating a client
-* */certs* - publicly available certificate containing public key (these can be generated using the `generate_cert.sh` script)
+* */jwks* - contains cryptographic information about public keys to authenticate tokens (these can be generated using the `gen_cert.py` script)
 * */fetch_token* - this is a user interface for fetching tokens from the auth server using the password credentials grant. This endpoint is purely for testing purposes, and uses JQuery HTTP Requests found in `auth_server/static/main.js` to fetch tokens.

--- a/nmosauth/README.md
+++ b/nmosauth/README.md
@@ -127,6 +127,6 @@ For a full list of endpoints please see `auth_server/security_api.py`. A prefix 
 
 * */token* - for requesting a token
 * */signup* - for adding a user
-* */register_client* - creating a client
+* */register-client* - creating a client
 * */jwks* - contains cryptographic information about public keys to authenticate tokens (these can be generated using the `gen_cert.py` script)
 * */fetch_token* - this is a user interface for fetching tokens from the auth server using the password credentials grant. This endpoint is purely for testing purposes, and uses JQuery HTTP Requests found in `auth_server/static/main.js` to fetch tokens.

--- a/nmosauth/auth_server/constants.py
+++ b/nmosauth/auth_server/constants.py
@@ -12,10 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Constants for nmos-auth defining filenames and directory locations"""
+"""Constants for nmos-auth defining filenames, locations and endpoints"""
 
 import os
 
+# Filenames and Locations
 NMOSAUTH_DIR = '/var/nmosauth'
 CERT_FILE = 'certificate.pem'
 CERT_PATH = os.path.join(NMOSAUTH_DIR, CERT_FILE)
@@ -24,5 +25,12 @@ PRIVKEY_PATH = os.path.join(NMOSAUTH_DIR, PRIVKEY_FILE)
 PUBKEY_FILE = 'pubkey.pem'
 PUBKEY_PATH = os.path.join(NMOSAUTH_DIR, PUBKEY_FILE)
 
-CERT_ENDPOINT = '/certs'
+# Endpoints
+JWK_ENDPOINT = 'jwks'
+TOKEN_ENDPOINT = 'token'
+REGISTER_ENDPOINT = 'register-client'
+AUTHORIZATION_ENDPOINT = 'authorize'
+REVOCATION_ENDPOINT = 'revoke'
+
+# Databse Info
 DATABASE_NAME = 'auth_db'

--- a/nmosauth/auth_server/constants.py
+++ b/nmosauth/auth_server/constants.py
@@ -21,5 +21,8 @@ CERT_FILE = 'certificate.pem'
 CERT_PATH = os.path.join(NMOSAUTH_DIR, CERT_FILE)
 PRIVKEY_FILE = 'privkey.pem'
 PRIVKEY_PATH = os.path.join(NMOSAUTH_DIR, PRIVKEY_FILE)
+PUBKEY_FILE = 'pubkey.pem'
+PUBKEY_PATH = os.path.join(NMOSAUTH_DIR, PUBKEY_FILE)
+
 CERT_ENDPOINT = '/certs'
 DATABASE_NAME = 'auth_db'

--- a/nmosauth/auth_server/security_api.py
+++ b/nmosauth/auth_server/security_api.py
@@ -290,7 +290,7 @@ class SecurityAPI(WebAPI):
 
     # route for JSON Web Key
     @route(AUTH_VERSION_ROOT + 'jwks/', methods=['GET'], auto_json=True)
-    def get_key(self):
+    def get_jwk(self):
         try:
             with open(PUBKEY_PATH, 'r') as myfile:
                 pub_key = myfile.read()

--- a/nmosauth/auth_server/security_api.py
+++ b/nmosauth/auth_server/security_api.py
@@ -14,6 +14,7 @@
 
 import os
 from datetime import date
+from socket import getfqdn
 from flask import request, session, send_from_directory, g
 from flask import render_template, redirect, url_for, jsonify, abort
 from werkzeug.security import gen_salt
@@ -29,7 +30,10 @@ from .oauth2 import authorization
 from .app import config_app
 from .db_utils import addAdminUser, addResourceOwner, getAdminUser, getResourceOwner
 from .db_utils import removeClient, removeResourceOwner
-from .constants import PUBKEY_PATH
+from .constants import (
+    PUBKEY_PATH, JWK_ENDPOINT, TOKEN_ENDPOINT, REGISTER_ENDPOINT,
+    AUTHORIZATION_ENDPOINT, REVOCATION_ENDPOINT
+)
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 
@@ -124,13 +128,37 @@ class SecurityAPI(WebAPI):
 
     @route(AUTH_VERSION_ROOT)
     def versionindex(self):
-        obj = ["register_client/", "revoke/", "authorize/", "token/", "certs/"]
+        obj = [
+            REGISTER_ENDPOINT + "/",
+            AUTHORIZATION_ENDPOINT + "/",
+            JWK_ENDPOINT + "/",
+            REVOCATION_ENDPOINT,
+            TOKEN_ENDPOINT
+        ]
         return (200, obj)
 
     @route(AUTH_VERSION_ROOT + 'test/', auto_json=True)
     @RequiresAuth(condition=True)
     def test(self):
         return (200, "Hello World")
+
+    @route('/.well-known/oauth-authorization-server/', methods=['GET'])
+    def server_metadata(self):
+        hostname = 'https://' + getfqdn()
+        namespace = hostname + AUTH_VERSION_ROOT
+        metadata = {
+            "issuer": hostname,
+            "authorization_endpoint": namespace + AUTHORIZATION_ENDPOINT,
+            "token_endpoint": namespace + TOKEN_ENDPOINT,
+            "token_endpoint_auth_methods_supported": ["client_secret_basic"],
+            "token_endpoint_auth_signing_alg_values_supported": [self.app.config["OAUTH2_JWT_ALG"]],
+            "jwks_uri": namespace + JWK_ENDPOINT,
+            "registration_endpoint": namespace + REGISTER_ENDPOINT,
+            "revocation_endpoint": namespace + REVOCATION_ENDPOINT,
+            "scopes_supported": ["is-04", "is-05"],
+            "response_types_supported": ["code"],
+        }
+        return (200, metadata)
 
     @route(AUTH_VERSION_ROOT + 'login/', methods=['GET', 'POST'], auto_json=False)
     def login(self):
@@ -189,7 +217,7 @@ class SecurityAPI(WebAPI):
     def signup_get(self):
         return render_template('signup.html')
 
-    @route(AUTH_VERSION_ROOT + 'register_client', methods=['POST'], auto_json=False)
+    @route(AUTH_VERSION_ROOT + REGISTER_ENDPOINT, methods=['POST'], auto_json=False)
     @admin_required
     def create_client_post(self):
         user = g.user
@@ -214,7 +242,7 @@ class SecurityAPI(WebAPI):
             client_info.update(client.client_metadata)
             return jsonify(client_info), 201
 
-    @route(AUTH_VERSION_ROOT + 'register_client/', methods=['GET'], auto_json=False)
+    @route(AUTH_VERSION_ROOT + REGISTER_ENDPOINT + '/', methods=['GET'], auto_json=False)
     @admin_required
     def create_client_get(self):
         return render_template('create_client.html')
@@ -233,7 +261,7 @@ class SecurityAPI(WebAPI):
         client = OAuth2Client.query.filter_by(user_id=user.id).first()
         return render_template('fetch_token.html', client=client)
 
-    @route(AUTH_VERSION_ROOT + 'authorize', methods=['POST'], auto_json=False)
+    @route(AUTH_VERSION_ROOT + AUTHORIZATION_ENDPOINT, methods=['POST'], auto_json=False)
     @owner_required
     def authorization_post(self):
         owner = g.owner
@@ -243,7 +271,7 @@ class SecurityAPI(WebAPI):
             grant_user = None
         return authorization.create_authorization_response(grant_user=grant_user)
 
-    @route(AUTH_VERSION_ROOT + 'authorize/', methods=['GET'], auto_json=False)
+    @route(AUTH_VERSION_ROOT + AUTHORIZATION_ENDPOINT + '/', methods=['GET'], auto_json=False)
     @owner_required
     def authorization_get(self):
         owner = g.owner
@@ -253,11 +281,11 @@ class SecurityAPI(WebAPI):
             return error.error
         return render_template('authorize.html', user=owner, grant=grant)
 
-    @route(AUTH_VERSION_ROOT + 'token', methods=['POST'], auto_json=False)
+    @route(AUTH_VERSION_ROOT + TOKEN_ENDPOINT, methods=['POST'], auto_json=False)
     def issue_token_post(self):
         return authorization.create_token_response()
 
-    @route(AUTH_VERSION_ROOT + 'revoke', methods=['POST'], auto_json=False)
+    @route(AUTH_VERSION_ROOT + REVOCATION_ENDPOINT, methods=['POST'], auto_json=False)
     def revoke_token_post(self):
         return authorization.create_endpoint_response('revocation')
 
@@ -289,7 +317,7 @@ class SecurityAPI(WebAPI):
         return redirect(url_for('_get_users'))
 
     # route for JSON Web Key
-    @route(AUTH_VERSION_ROOT + 'jwks/', methods=['GET'], auto_json=True)
+    @route(AUTH_VERSION_ROOT + JWK_ENDPOINT + '/', methods=['GET'], auto_json=True)
     def get_jwk(self):
         try:
             with open(PUBKEY_PATH, 'r') as myfile:

--- a/nmosauth/auth_server/security_service.py
+++ b/nmosauth/auth_server/security_service.py
@@ -80,6 +80,7 @@ class SecurityService:
             self.httpServer.started.wait()
 
         if self.httpServer.failed is not None:
+            self._cleanup()
             raise self.httpServer.failed
 
         self.logger.writeInfo("Running on port: {}".format(self.httpServer.port))
@@ -89,7 +90,6 @@ class SecurityService:
         self.start()
         while self.running:
             time.sleep(1)
-        self._cleanup()
 
     def _cleanup(self):
         if self.mdns:
@@ -108,8 +108,8 @@ class SecurityService:
         self.stop()
 
     def stop(self):
-        self.running = False
         self._cleanup()
+        self.running = False
 
 
 if __name__ == '__main__':

--- a/nmosauth/auth_server/security_service.py
+++ b/nmosauth/auth_server/security_service.py
@@ -99,12 +99,11 @@ class SecurityService:
                 self.logger.writeInfo("mDNS stopped gracefully")
             except Exception as e:
                 self.logger.writeWarning("Could not stop mDNS gracefully: {}".format(e))
-
         self.httpServer.stop()
         self.logger.writeInfo("Stopped Http Server")
 
     def sig_handler(self):
-        self.logger.writeInfo('Pressed ctrl+c')
+        print('Pressed ctrl+c')
         self.stop()
 
     def stop(self):

--- a/nmosauth/auth_server/templates/layout.html
+++ b/nmosauth/auth_server/templates/layout.html
@@ -25,7 +25,7 @@ limitations under the License. -->
       <h1><a href="{{ url_for('_home') }}">R&amp;D Authorisation Server</a></h1>
       <a href="{{ url_for('_create_client_get') }}">Register Client</a>
       <a href="{{ url_for('_fetch_token') }}">Request Token</a>
-      <a href="{{ url_for('_get_cert') }}">Certificates</a>
+      <a href="{{ url_for('_get_jwk') }}">Certificates</a>
       <a href="{{ url_for('_get_users') }}">Users</a>
     </div>
     <div class="page">

--- a/nmosauth/certs/gen_cert.py
+++ b/nmosauth/certs/gen_cert.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python3
 
-from OpenSSL import crypto
 import os
-
-from nmosauth.auth_server.constants import CERT_PATH, PRIVKEY_PATH
+from OpenSSL import crypto
+from nmosauth.auth_server.constants import CERT_PATH, PRIVKEY_PATH, PUBKEY_PATH
 
 
 def create_self_signed_cert():
@@ -34,9 +33,10 @@ def create_self_signed_cert():
     open(PRIVKEY_PATH, "wt").write(
         crypto.dump_privatekey(crypto.FILETYPE_PEM, k).decode('utf-8')
     )
-
+    open(PUBKEY_PATH, "wt").write(
+        crypto.dump_publickey(crypto.FILETYPE_PEM, k).decode('utf-8')
+    )
     # Change permissions to Read-Only for security
-    os.chmod(CERT_PATH, 0o400)
     os.chmod(PRIVKEY_PATH, 0o400)
 
 

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ GEN_CERT_PATH = os.path.join(NMOSAUTH_DIR, GEN_CERT_FILE)
 
 # Basic metadata
 name = "nmos-auth"
-version = "1.3.3"
+version = "1.3.4"
 description = "OAuth2 Server Implementation"
 url = 'https://github.com/bbc/nmos-auth-server'
 author = 'Danny Meloy'

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -85,11 +85,11 @@ class TestNmosAuthServer(unittest.TestCase):
             rv = client.post(VERSION_ROOT + '/authorize', headers=headers)
             self.assertEqual(rv.status_code, 302)
             # Register client redirects to login page
-            rv = client.get(VERSION_ROOT + '/register_client/', headers=headers)
+            rv = client.get(VERSION_ROOT + '/register-client/', headers=headers)
             self.assertEqual(rv.status_code, 302)
             # Posting to Register client returns 401 if not expecting html
             with self.assertRaises(HTTPException) as http_error:
-                rv = client.post(VERSION_ROOT + '/register_client')
+                rv = client.post(VERSION_ROOT + '/register-client')
                 self.assertEqual(http_error.exception.code, 401)
                 rv = client.post(VERSION_ROOT + '/authorize')
                 self.assertEqual(http_error.exception.code, 401)
@@ -101,14 +101,14 @@ class TestNmosAuthServer(unittest.TestCase):
         headers = self.auth_headers(TEST_USERNAME, TEST_PASSWORD)
         with self.client as client:
             # Get /register_client returns 200 status code
-            rv = client.get(VERSION_ROOT + '/register_client/', headers=headers)
+            rv = client.get(VERSION_ROOT + '/register-client/', headers=headers)
             self.assertEqual(rv.status_code, 200)
             mockGetAdminUser.assert_called_with(self.testUser.username)
 
             # Get /register_client with incorrect credentials returns Unauthorized
             headers = self.auth_headers("bob", "wrong_password")
             with self.assertRaises(HTTPException) as http_error:
-                client.get(VERSION_ROOT + '/register_client/', headers=headers)
+                client.get(VERSION_ROOT + '/register-client/', headers=headers)
                 self.assertEqual(http_error.exception.code, 401)
 
     @mock.patch("nmosauth.auth_server.security_api.render_template")
@@ -162,7 +162,7 @@ class TestNmosAuthServer(unittest.TestCase):
         user_headers = self.auth_headers(TEST_USERNAME, TEST_PASSWORD)
         with mock.patch("nmosauth.auth_server.security_api.session") as mock_session:
             mock_session.__getitem__.return_value = None
-            with self.client.post(VERSION_ROOT + '/register_client', data=register_data,
+            with self.client.post(VERSION_ROOT + '/register-client', data=register_data,
                                   headers=user_headers, follow_redirects=True) as rv:
                 self.assertEqual(rv.status_code, 201, rv.data)
                 self.client_metadata = json.loads(rv.get_data(as_text=True))


### PR DESCRIPTION
I'll no doubt have some minor test changes, but this should serve JSON Web Keys at the `/jwks` endpoint. It currently only serves a single key from the file system, but this can be extended once we have an idea how implementing JSON Web Key Sets and Key ID's (`kid`) are going to look like. 

I've started work modifying nmos-common to discover and parse the JWKs instead of just plain certificates. 