### PR TITLE
Upgrade client registration and imports for authlib v0.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # NMOS Authorization API Implementation Changelog
 
+## 1.4.0
+- Upgrade to authlib 0.13 and update client registration view function.
+
 ## 1.3.4
 - Change from /certs endpoint to serving JSON Web Keys at /jwks.
   Host server metadata endpoint at `/.well-known/oauth-authorization-server`.

--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ The core of the implementation uses the [Authlib](https://authlib.org/) Library,
 ### System Requirements
 
 *   Linux (untested on Windows and Mac)
-*   Python 2.7 and 3.x
-*   Python Pip
+*   Python 3.x
+*   Python Pip3
 
-### Python Requirements
+### Python3 Requirements
 
 These should be installed automatically as part of the install process.
 
@@ -42,28 +42,28 @@ To install from pip:
 
 ```bash
 # Install From Pip
-$ sudo pip install nmos-auth --no-binary nmos-auth
+$ sudo pip3 install nmos-auth --no-binary nmos-auth
 ```
 
-For pip installations from source:
+For pip3 installations from source:
 
 ```bash
 # Change to top-level directory
 $ cd nmos-auth-server
 
 # Install via pip locally
-$ sudo pip install . --no-binary nmos-auth
+$ sudo pip3 install . --no-binary nmos-auth
 ```
 
 For basic setuptools installations:
 
 ```bash
 # Install Python setuptools
-$ pip install setuptools
+$ sudo pip3 install setuptools
 
 # Install the package
 $ cd nmos-auth-server
-$ sudo python setup.py install
+$ sudo python3 setup.py install
 ```
 
 ### Testing
@@ -71,7 +71,7 @@ $ sudo python setup.py install
 Testing of the package can be achieved using tox:
 ```bash
 # Install tox
-pip install tox
+sudo pip3 install tox
 
 # Run tests using tox environment for Python3
 cd nmos-auth-server
@@ -105,11 +105,11 @@ For pure Python usage:
 # Execute service file
 $ sudo /usr/bin/nmosauth
 ```
-If installing via a Debian package (e.g. using apt-get), Systemd service files should be placed in system directories. The service can be restarted using:
+If installing via a Debian package (e.g. using apt-get, dpkg, etc), Systemd service files should be placed in system directories. The service can be restarted using:
 
 ```bash
 # Run Service using SystemD
-sudo systemctl restart python-nmos-auth
+sudo systemctl restart python3-nmos-auth
 ```
 
 ### Getting Started

--- a/nmosauth/auth_server/models.py
+++ b/nmosauth/auth_server/models.py
@@ -14,7 +14,7 @@
 
 import time
 from flask_sqlalchemy import SQLAlchemy
-from authlib.flask.oauth2.sqla import (
+from authlib.integrations.sqla_oauth2 import (
     OAuth2ClientMixin,
     OAuth2AuthorizationCodeMixin,
     OAuth2TokenMixin,

--- a/nmosauth/auth_server/oauth2.py
+++ b/nmosauth/auth_server/oauth2.py
@@ -71,9 +71,9 @@ class PasswordGrant(grants.ResourceOwnerPasswordCredentialsGrant):
 
 class RefreshTokenGrant(grants.RefreshTokenGrant):
     def authenticate_refresh_token(self, refresh_token):
-        item = OAuth2Token.query.filter_by(refresh_token=refresh_token).first()
-        if item and not item.is_refresh_token_expired():
-            return item
+        token = OAuth2Token.query.filter_by(refresh_token=refresh_token).first()
+        if token and not token.revoked and not token.is_refresh_token_expired():
+            return token
 
     def authenticate_user(self, credential):
         return getResourceOwner(credential.user_id)

--- a/nmosauth/auth_server/oauth2.py
+++ b/nmosauth/auth_server/oauth2.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from authlib.flask.oauth2 import AuthorizationServer, ResourceProtector
-from authlib.flask.oauth2.sqla import (
+from authlib.integrations.flask_oauth2 import AuthorizationServer, ResourceProtector
+from authlib.integrations.sqla_oauth2 import (
     create_query_client_func,
     create_save_token_func,
     create_revocation_endpoint,
@@ -77,6 +77,10 @@ class RefreshTokenGrant(grants.RefreshTokenGrant):
 
     def authenticate_user(self, credential):
         return getResourceOwner(credential.user_id)
+
+    def revoke_old_credential(self, token_object):
+        token_object.revoked = True
+        db.session.commit()
 
 
 query_client = create_query_client_func(db.session, OAuth2Client)

--- a/nmosauth/auth_server/security_api.py
+++ b/nmosauth/auth_server/security_api.py
@@ -256,7 +256,7 @@ class SecurityAPI(WebAPI):
             "redirect_uris": self.split_data(client_data.get("redirect_uris")),
             "response_types": self.split_data(client_data.get("response_types")),
             "scope": client_data.get("scope"),
-            "token_endpoint_auth_method": client_data.get("token_endpoint_auth_method")
+            "token_endpoint_auth_method": client_data.get("token_endpoint_auth_method", "client_secret_basic")
         }
         client.set_client_metadata(client_metadata)
 

--- a/nmosauth/auth_server/security_api.py
+++ b/nmosauth/auth_server/security_api.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+import json
 from time import time
 from socket import getfqdn
 from flask import request, session, send_from_directory, g
@@ -266,7 +267,7 @@ class SecurityAPI(WebAPI):
             return redirect(url_for('_home'))
         else:
             client_info = client.client_info.copy()
-            client_info.update(client.client_metadata)
+            client_info.update(json.loads(client._client_metadata))
             return jsonify(client_info), 201
 
     @route(AUTH_VERSION_ROOT + REGISTER_ENDPOINT + '/', methods=['GET'], auto_json=False)

--- a/nmosauth/auth_server/security_api.py
+++ b/nmosauth/auth_server/security_api.py
@@ -220,22 +220,46 @@ class SecurityAPI(WebAPI):
     def signup_get(self):
         return render_template('signup.html')
 
+    @staticmethod
+    def split_data(data):
+        if isinstance(data, str):
+            return data.splitlines()
+        elif isinstance(data, list):
+            return data
+
     @route(AUTH_VERSION_ROOT + REGISTER_ENDPOINT, methods=['POST'], auto_json=False)
     @admin_required
     def create_client_post(self):
         user = g.user
-        if "application/json" in request.headers["Content-Type"]:
-            client = OAuth2Client(**request.get_json())
-        elif "application/x-www-form-urlencoded" in request.headers["Content-Type"]:
-            client = OAuth2Client(**request.form.to_dict(flat=True))
-        else:
-            raise InvalidRequestError
-        client.user_id = user.id
-        client.client_id = gen_salt(24)
+        client_id = gen_salt(24)
+        client_id_issued_at = int(time())
+        client = OAuth2Client(
+            client_id=client_id,
+            client_id_issued_at=client_id_issued_at,
+            user_id=user.id,
+        )
         if client.token_endpoint_auth_method == 'none':
             client.client_secret = ''
         else:
             client.client_secret = gen_salt(48)
+
+        if "application/json" in request.headers["Content-Type"]:
+            client_data = request.get_json()
+        elif "application/x-www-form-urlencoded" in request.headers["Content-Type"]:
+            client_data = request.form
+        else:
+            raise InvalidRequestError
+        client_metadata = {
+            "client_name": client_data.get("client_name"),
+            "client_uri": client_data.get("client_uri"),
+            "grant_types": self.split_data(client_data.get("grant_types")),
+            "redirect_uris": self.split_data(client_data.get("redirect_uris")),
+            "response_types": self.split_data(client_data.get("response_types")),
+            "scope": client_data.get("scope"),
+            "token_endpoint_auth_method": client_data.get("token_endpoint_auth_method")
+        }
+        client.set_client_metadata(client_metadata)
+
         db.session.add(client)
         db.session.commit()
         if 'id' in session:

--- a/nmosauth/auth_server/templates/create_client.html
+++ b/nmosauth/auth_server/templates/create_client.html
@@ -41,8 +41,7 @@ limitations under the License. -->
     <textarea name="grant_types" cols="30" rows="10" placeholder="grant name">
 password
 authorization_code
-refresh_token
-    </textarea>
+refresh_token</textarea>
   </label>
   <label>
     <span>Allowed Response Types:</span>

--- a/nmosauth/auth_server/templates/create_client.html
+++ b/nmosauth/auth_server/templates/create_client.html
@@ -34,11 +34,11 @@ limitations under the License. -->
   </label>
   <label>
     <span>Redirect URIs:</span>
-    <textarea name="redirect_uri" cols="30" rows="10" >http://ipstudio-master.rd.bbc.co.uk/ips-web/</textarea>
+    <textarea name="redirect_uris" cols="30" rows="10" >http://ipstudio-master.rd.bbc.co.uk/ips-web/</textarea>
   </label>
   <label>
     <span>Allowed Grant Types:</span>
-    <textarea name="grant_type" cols="30" rows="10" placeholder="grant name">
+    <textarea name="grant_types" cols="30" rows="10" placeholder="grant name">
 password
 authorization_code
 refresh_token
@@ -46,7 +46,7 @@ refresh_token
   </label>
   <label>
     <span>Allowed Response Types:</span>
-    <textarea name="response_type" cols="30" rows="10">code</textarea>
+    <textarea name="response_types" cols="30" rows="10">code</textarea>
   </label>
   <label>
     <span>Token Endpoint Auth Method:</span>

--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,7 @@ packages_required = [
     "gevent",
     "nmoscommon",
     "werkzeug>=0.13",
-    "authlib>=0.11",
+    "authlib>=0.13",
     "pyopenssl>=16.0",
     "cryptography>=1.5"
 ]

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ GEN_CERT_PATH = os.path.join(NMOSAUTH_DIR, GEN_CERT_FILE)
 
 # Basic metadata
 name = "nmos-auth"
-version = "1.3.4"
+version = "1.4.0"
 description = "OAuth2 Server Implementation"
 url = 'https://github.com/bbc/nmos-auth-server'
 author = 'Danny Meloy'

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -154,15 +154,15 @@ class TestNmosAuthServer(unittest.TestCase):
             'client_name': 'R&D Web Router',
             'client_uri': 'http://ipstudio-master.rd.bbc.co.uk/ips-web/#/web-router',
             'scope': 'is-04 is-05',
-            'redirect_uri': 'http://www.example.com',
-            'grant_type': 'password\nauthorization_code',
-            'response_type': 'code',
+            'redirect_uris': ['http://www.example.com'],
+            'grant_types': ['password', 'authorization_code', 'refresh_token'],
+            'response_types': ['code'],
             'token_endpoint_auth_method': 'client_secret_basic'
         }
         user_headers = self.auth_headers(TEST_USERNAME, TEST_PASSWORD)
         with mock.patch("nmosauth.auth_server.security_api.session") as mock_session:
             mock_session.__getitem__.return_value = None
-            with self.client.post(VERSION_ROOT + '/register-client', data=register_data,
+            with self.client.post(VERSION_ROOT + '/register-client', json=register_data,
                                   headers=user_headers, follow_redirects=True) as rv:
                 self.assertEqual(rv.status_code, 201, rv.data)
                 self.client_metadata = json.loads(rv.get_data(as_text=True))
@@ -212,7 +212,7 @@ class TestNmosAuthServer(unittest.TestCase):
             self.assertTrue("error" not in authorize_headers["location"] and "code" in authorize_headers["location"])
 
             redirect_uri, query_string = rv.headers["location"].split('?')
-            self.assertEqual(redirect_uri, register_data["redirect_uri"])
+            self.assertEqual(redirect_uri, register_data["redirect_uris"][0])
 
             parsed_query = parse_qs(query_string)
             auth_code = parsed_query["code"][0]


### PR DESCRIPTION
This updates the auth server to use version 0.13 of the `authlib` library:
- Breaking change of adding the `revoke_old_credential` function in v0.12 in the RefreshGrant class has been added
- Re-writing of the underpinning `OAuth2Client` class meant that registration has to be done in a slightly different manner.
- Import names have also been altered due to deprecation warnings.