### PR TITLE
Tests and Metadata Endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # NMOS Authorization API Implementation Changelog
 
+## 1.4.4
+- Add fields to metadata endpoint. Add refresh token tests.
+- Change request token page to use client credentials grant.
+
 ## 1.4.3
 - Add validation for server metadata and upper pin werkzeug.
 

--- a/nmosauth/auth_server/app.py
+++ b/nmosauth/auth_server/app.py
@@ -30,8 +30,8 @@ def config_app(app, confClass='BaseConfig', config=None):
     app.config.from_object(settings + '.' + confClass)
 
     # load environment configuration
-    if 'WEBSITE_CONF' in os.environ:
-        app.config.from_envvar('WEBSITE_CONF')
+    if 'AUTH_SERVER_CONF' in os.environ:
+        app.config.from_envvar('AUTH_SERVER_CONF')
 
     # load app specified configuration
     if config is not None:

--- a/nmosauth/auth_server/client_registration.py
+++ b/nmosauth/auth_server/client_registration.py
@@ -1,0 +1,37 @@
+# Copyright 2019 British Broadcasting Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from flask import g
+from authlib.oauth2.rfc7591 import ClientRegistrationEndpoint as _ClientRegistrationEndpoint
+
+from .db_utils import addOAuthClient
+
+
+class ClientRegistrationEndpoint(_ClientRegistrationEndpoint):
+
+    def authenticate_user(self, request):
+        return g.admin
+
+    def create_endpoint_request(self, request):
+        if "application/x-www-form-urlencoded" in request.headers["Content-Type"]:
+            form_data = request.form.copy()
+            for make_list in ["grant_types", "response_types", "redirect_uris"]:
+                form_data[make_list] = form_data[make_list].splitlines()
+            request.form = form_data
+            return self.server.create_oauth2_request(request)
+        else:
+            return self.server.create_json_request(request)
+
+    def save_client(self, client_info, client_metadata, user):
+        return addOAuthClient(client_info, client_metadata, user)

--- a/nmosauth/auth_server/constants.py
+++ b/nmosauth/auth_server/constants.py
@@ -25,6 +25,13 @@ PRIVKEY_PATH = os.path.join(NMOSAUTH_DIR, PRIVKEY_FILE)
 PUBKEY_FILE = 'pubkey.pem'
 PUBKEY_PATH = os.path.join(NMOSAUTH_DIR, PUBKEY_FILE)
 
+# API Namespace
+APINAMESPACE = "x-nmos"
+APINAME = "auth"
+APIVERSION = "v1.0"
+AUTH_API_ROOT = '/{}/{}'.format(APINAMESPACE, APINAME)
+AUTH_VERSION_ROOT = '{}/{}/'.format(AUTH_API_ROOT, APIVERSION)
+
 # Default Endpoints
 JWK_ENDPOINT = 'jwks'
 TOKEN_ENDPOINT = 'token'

--- a/nmosauth/auth_server/constants.py
+++ b/nmosauth/auth_server/constants.py
@@ -31,6 +31,7 @@ TOKEN_ENDPOINT = 'token'
 REGISTER_ENDPOINT = 'register'
 AUTHORIZATION_ENDPOINT = 'authorize'
 REVOCATION_ENDPOINT = 'revoke'
+WELL_KNOWN_ENDPOINT = '/.well-known/oauth-authorization-server/'
 
 # Databse Info
 DATABASE_NAME = 'auth_db'

--- a/nmosauth/auth_server/db_utils.py
+++ b/nmosauth/auth_server/db_utils.py
@@ -42,13 +42,15 @@ def add(entry):
     db.session.commit()
 
 
-def addResourceOwner(user, username, password, registration, query, node, connection):
+def addResourceOwner(
+        user, username, password, registration, query, node, connection, netctrl, events, channelmapping):
     password_hash = generate_password_hash(password)
     if ResourceOwner.query.filter_by(username=username).scalar() is None:
         access = ResourceOwner(
             user_id=user.id, username=username, password=password_hash,
             registration_access=registration, query_access=query,
-            node_access=node, connection_access=connection)
+            node_access=node, connection_access=connection, netctrl_access=netctrl,
+            events_access=events, channelmapping_access=channelmapping)
         add(access)
         return access
 

--- a/nmosauth/auth_server/db_utils.py
+++ b/nmosauth/auth_server/db_utils.py
@@ -62,6 +62,18 @@ def addAdminUser(username, password):
         add(user)
         return user
 
+
+def addOAuthClient(client_info, client_metadata, user):
+    if OAuth2Client.query.filter_by(client_id=client_info['client_id']).scalar() is None:
+        client = OAuth2Client(
+            user_id=user.id,
+            client_id=client_info['client_id'],
+            client_secret=client_info['client_secret'],
+        )
+        client.set_client_metadata(client_metadata)
+        add(client)
+        return client
+
 # -------------------- READ ------------------------- #
 # from nmosauth.auth_server.db_utils import *
 

--- a/nmosauth/auth_server/metadata.py
+++ b/nmosauth/auth_server/metadata.py
@@ -1,0 +1,51 @@
+# Copyright 2019 British Broadcasting Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from socket import getfqdn
+from authlib.oauth2.rfc8414 import AuthorizationServerMetadata
+
+from .config import config # noqa E402
+from .constants import (
+    JWK_ENDPOINT, TOKEN_ENDPOINT, REGISTER_ENDPOINT,
+    AUTHORIZATION_ENDPOINT, REVOCATION_ENDPOINT, AUTH_VERSION_ROOT
+)
+
+SCOPES_SUPPORTED = ["registration", "node", "query", "connection", "netctrl", "events", "channelmapping"]
+GRANT_TYPES_SUPPORTED = ["authorization_code", "refresh_token", "client_credentials"]
+RESPONSE_TYPES_SUPPORTED = ["code"]
+TOKEN_ENDPOINT_AUTH_METHODS_SUPPORTED = ["client_secret_basic"]
+CODE_CHALLENGE_METHODS_SUPPORTED = ["S256"]
+
+
+def create_metadata(app):
+    protocol = "https" if config.get("https_mode") == "enabled" else "http"
+    hostname = protocol + '://' + getfqdn()
+    namespace = hostname + AUTH_VERSION_ROOT
+    metadata_dict = {
+        "issuer": hostname,
+        "authorization_endpoint": namespace + AUTHORIZATION_ENDPOINT,
+        "token_endpoint": namespace + TOKEN_ENDPOINT,
+        "token_endpoint_auth_methods_supported": TOKEN_ENDPOINT_AUTH_METHODS_SUPPORTED,
+        "token_endpoint_auth_signing_alg_values_supported": [app.config["OAUTH2_JWT_ALG"]],
+        "jwks_uri": namespace + JWK_ENDPOINT,
+        "registration_endpoint": namespace + REGISTER_ENDPOINT,
+        "revocation_endpoint": namespace + REVOCATION_ENDPOINT,
+        "scopes_supported": SCOPES_SUPPORTED,
+        "response_types_supported": RESPONSE_TYPES_SUPPORTED,
+        "grant_types_supported": GRANT_TYPES_SUPPORTED,
+        "code_challenge_methods_supported": CODE_CHALLENGE_METHODS_SUPPORTED
+    }
+    # Validate Metadata
+    metadata = AuthorizationServerMetadata(metadata_dict)
+    return metadata

--- a/nmosauth/auth_server/models.py
+++ b/nmosauth/auth_server/models.py
@@ -91,10 +91,14 @@ class ResourceOwner(db.Model):
     username = db.Column(db.String(40), unique=True, nullable=False)
     password = db.Column(db.String(20))
 
+    # Permissions of User for each NMOs API
     registration_access = db.Column(db.String(25))
     query_access = db.Column(db.String(25))
     node_access = db.Column(db.String(25))
     connection_access = db.Column(db.String(25))
+    netctrl_access = db.Column(db.String(25))
+    events_access = db.Column(db.String(25))
+    channelmapping_access = db.Column(db.String(25))
 
     def get_user_id(self):
         return self.id

--- a/nmosauth/auth_server/models.py
+++ b/nmosauth/auth_server/models.py
@@ -72,7 +72,7 @@ class OAuth2Token(db.Model, OAuth2TokenMixin):
     user_id = db.Column(
         db.Integer, db.ForeignKey('admin_user.id', ondelete='CASCADE'))
     admin_user = db.relationship('AdminUser')
-    access_token = db.Column(db.String(255), nullable=False)
+    access_token = db.Column(db.String(1000), nullable=False)
 
     def is_refresh_token_expired(self):
         expires_at = self.issued_at + self.expires_in * 1440
@@ -90,7 +90,7 @@ class ResourceOwner(db.Model):
     username = db.Column(db.String(40), unique=True, nullable=False)
     password = db.Column(db.String(20))
 
-    # Permissions of User for each NMOs API
+    # Permissions of User for each NMOS API
     registration_access = db.Column(db.String(25))
     query_access = db.Column(db.String(25))
     node_access = db.Column(db.String(25))

--- a/nmosauth/auth_server/models.py
+++ b/nmosauth/auth_server/models.py
@@ -21,7 +21,6 @@ from authlib.integrations.sqla_oauth2 import (
     OAuth2TokenMixin,
 )
 
-
 __all__ = ['db', 'AdminUser', 'OAuth2Client',
            'OAuth2AuthorizationCode', 'OAuth2Token', 'ResourceOwner']
 

--- a/nmosauth/auth_server/oauth2.py
+++ b/nmosauth/auth_server/oauth2.py
@@ -104,11 +104,11 @@ require_oauth = ResourceProtector()
 def config_oauth(app):
     authorization.init_app(app)
 
-    # support all grants
-    authorization.register_grant(grants.ImplicitGrant)
+    # Comment out unsupported grants
+    # authorization.register_grant(grants.ImplicitGrant)
+    # authorization.register_grant(PasswordGrant)
     authorization.register_grant(grants.ClientCredentialsGrant)
     authorization.register_grant(AuthorizationCodeGrant, [CodeChallenge(required=app.config["PKCE_REQUIRED"])])
-    authorization.register_grant(PasswordGrant)
     authorization.register_grant(RefreshTokenGrant)
 
     # support revocation

--- a/nmosauth/auth_server/security_api.py
+++ b/nmosauth/auth_server/security_api.py
@@ -225,7 +225,8 @@ class SecurityAPI(WebAPI):
         # Create Resource Owner account for Admin with full Write privileges
         addResourceOwner(
             user, username=username, password=password, registration="write",
-            query="write", node="write", connection="write")
+            query="write", node="write", connection="write", netctrl="write",
+            events="write", channelmapping="write")
         session['admin'] = user.id
         return redirect(url_for('_home'))
 
@@ -349,12 +350,17 @@ class SecurityAPI(WebAPI):
         query = request.form.get("query")
         node = request.form.get("node")
         connection = request.form.get("connection")
+        netctrl = request.form.get("netctrl")
+        events = request.form.get("events")
+        channelmapping = request.form.get("channelmapping")
+
         if any(i in [None, ''] for i in (user, username, password)):
             return redirect(url_for('_get_users'))
         else:
             addResourceOwner(
                 user, username=username, password=password, registration=registration,
-                query=query, node=node, connection=connection)
+                query=query, node=node, connection=connection, netctrl=netctrl,
+                events=events, channelmapping=channelmapping)
         return redirect(url_for('_get_users'))
 
     @route(AUTH_VERSION_ROOT + 'users/<username>', methods=['GET'], auto_json=False)

--- a/nmosauth/auth_server/security_service.py
+++ b/nmosauth/auth_server/security_service.py
@@ -43,7 +43,7 @@ DNS_SD_TYPE = '_nmos-auth._tcp'
 
 class SecurityService:
 
-    CONF_CLASS = "ProductionConfig"
+    CONF_CLASS = "BaseConfig"
 
     def __init__(self, logger=None):
         self.logger = Logger("nmosauth", logger)

--- a/nmosauth/auth_server/static/main.js
+++ b/nmosauth/auth_server/static/main.js
@@ -22,25 +22,15 @@ $(function getToken() {
   var port = window.location.port;
   var host = window.location.hostname;
   $("#token").click(function(){
-    username = document.getElementById("username").value
-    password = document.getElementById("password").value
-    scope = document.getElementById("scope").value
+    var client_id = document.getElementById("client_id").value;
+    var client_secret = document.getElementById("client_secret").value;
     var requestPayload = {
-      'grant_type': 'password',
-      'username': username.trim(),
-      'password': password,
-      'scope': scope.trim()
+      'grant_type': 'client_credentials'
     };
-    if (username == "" || password == "" || scope == "") {
+    if (client_id == "" || client_secret == "") {
       alert('Error: Please complete all fields');
       return false;
     }
-    if (requestPayload.scope.split(" ").length > 1) {
-      alert('Error: Please only enter a single scope');
-      return false;
-    }
-    var client_id = document.getElementById("client_id").value;
-    var client_secret = document.getElementById("client_secret").value;
     $.ajax({
       url: '//' + host + ':' + port + '/x-nmos/auth/v1.0/token',
       type: 'POST',
@@ -88,11 +78,11 @@ var collapsibles = document.getElementsByClassName("collapsible");
 Object.values(collapsibles).forEach(function(collapsible) {
   collapsible.addEventListener("click", function() {
     collapsible.classList.toggle("active");
-    var content = collapsible.nextElementSibling
+    var content = collapsible.nextElementSibling;
     if (content.style.maxHeight) {
-      content.style.maxHeight = null
+      content.style.maxHeight = null;
     } else {
       content.style.maxHeight = content.scrollHeight + "px";
     }
-  })
-})
+  });
+});

--- a/nmosauth/auth_server/templates/create_client.html
+++ b/nmosauth/auth_server/templates/create_client.html
@@ -29,7 +29,7 @@ limitations under the License. -->
   </label>
   <label>
     <span>Allowed Scope:</span>
-    <input type="text" name="scope" value="registration query node connection"
+    <input type="text" name="scope" value="registration query node connection netctrl events channelmapping"
             placeholder="space delimited list of scopes">
   </label>
   <label>

--- a/nmosauth/auth_server/templates/create_client.html
+++ b/nmosauth/auth_server/templates/create_client.html
@@ -40,7 +40,8 @@ limitations under the License. -->
     <span>Allowed Grant Types:</span>
     <textarea name="grant_types" cols="30" rows="10" placeholder="grant name">
 authorization_code
-refresh_token</textarea>
+refresh_token
+client_credentials</textarea>
   </label>
   <label>
     <span>Allowed Response Types:</span>

--- a/nmosauth/auth_server/templates/fetch_token.html
+++ b/nmosauth/auth_server/templates/fetch_token.html
@@ -15,7 +15,11 @@ limitations under the License. -->
 {% extends "layout.html" %}
 {% block body %}
 
-<h2>Fetch Token</h2>
+<h2>Request Token</h2>
+
+<p>This page will return an example JSON Web Token using the Client Credentials Grant (provided the given client has been registered with the Client Credentials Grant type.)</p>
+
+<p><i>NOTE: The returned token will not populate the 'scope' and 'x-nmos-api' claims due to the CC Grant not identifying a specific user</i></p>
 
 <form action="" method="post">
   <label>
@@ -28,27 +32,6 @@ limitations under the License. -->
     <span>Client Secret:</span>
     <input type="text" name="client_secret" id="client_secret"
            placeholder="client_secret" value="{{client.client_secret}}">
-    <br>
-  </label>
-  <label>
-    <span>Username:</span>
-    <input type="text" name="username" id="username">
-    <br>
-  </label>
-  <label>
-    <span>Password:</span>
-    <input type="text" name="password" id="password">
-    <br>
-  </label>
-  <label>
-    <span>Scope:</span>
-    <select name="scope" id="scope">
-        <option value="registration">registration</option>
-        <option value="query">query</option>
-        <option value="node">node</option>
-        <option value="connection">connection</option>
-
-    </select>
     <br>
   </label>
 </form>

--- a/nmosauth/auth_server/templates/layout.html
+++ b/nmosauth/auth_server/templates/layout.html
@@ -24,9 +24,10 @@ limitations under the License. -->
     <div class="navbar">
       <h1><a href="{{ url_for('_home') }}">R&amp;D Authorisation Server</a></h1>
       <a href="{{ url_for('_create_client_get') }}">Register Client</a>
-      <a href="{{ url_for('_fetch_token') }}">Request Token</a>
+      <a href="{{ url_for('_request_token') }}">Request Token</a>
       <a href="{{ url_for('_get_jwk') }}">Certificates</a>
       <a href="{{ url_for('_get_users') }}">Users</a>
+      <a href="{{ url_for('_server_metadata') }}">Server Metadata</a>
     </div>
     <div class="page">
       {% block body %}{% endblock %}

--- a/nmosauth/auth_server/templates/layout.html
+++ b/nmosauth/auth_server/templates/layout.html
@@ -25,7 +25,7 @@ limitations under the License. -->
       <h1><a href="{{ url_for('_home') }}">R&amp;D Authorisation Server</a></h1>
       <a href="{{ url_for('_create_client_get') }}">Register Client</a>
       <a href="{{ url_for('_request_token') }}">Request Token</a>
-      <a href="{{ url_for('_get_jwk') }}">Certificates</a>
+      <a href="{{ url_for('_get_jwk') }}">JWKS</a>
       <a href="{{ url_for('_get_users') }}">Users</a>
       <a href="{{ url_for('_server_metadata') }}">Server Metadata</a>
     </div>

--- a/nmosauth/auth_server/templates/users.html
+++ b/nmosauth/auth_server/templates/users.html
@@ -55,6 +55,30 @@ limitations under the License. -->
       </select>
       <br>
     </label>
+    <label>
+      <span>IS-06 Network Control Access Rights:</span>
+      <select name="netctrl" id="netctrl">
+        <option value="read">Read</option>
+        <option value="write">Write</option>
+      </select>
+      <br>
+    </label>
+    <label>
+      <span>IS-07 Event and Tally Access Rights:</span>
+      <select name="events" id="events">
+        <option value="read">Read</option>
+        <option value="write">Write</option>
+      </select>
+      <br>
+    </label>
+    <label>
+      <span>IS-08 Audio Channel Mapping Access Rights:</span>
+      <select name="channelmapping" id="channelmapping">
+        <option value="read">Read</option>
+        <option value="write">Write</option>
+      </select>
+      <br>
+    </label>
     <button type="submit">Add User</button>
   </form>
 </div>
@@ -73,6 +97,9 @@ limitations under the License. -->
     <p>IS-04 Query Access Rights: {{ owner.query_access }}</p>
     <p>IS-04 Node Access Rights: {{ owner.node_access }}</p>
     <p>IS-05 Connection Management Access Rights: {{ owner.connection_access }}</p>
+    <p>IS-06 Network Control Access Rights: {{ owner.netctrl_access }}</p>
+    <p>IS-07 Event and Tally Access Rights: {{ owner.events_access }}</p>
+    <p>IS-08 Audio Channel Mapping Access Rights: {{ owner.channelmapping_access }}</p>    
   </div><br>
 {% endfor %}
 

--- a/nmosauth/auth_server/token_generator.py
+++ b/nmosauth/auth_server/token_generator.py
@@ -20,7 +20,7 @@ from authlib.jose import jwt
 from .oauth2 import authorization
 from .constants import NMOSAUTH_DIR, PRIVKEY_FILE
 
-SCOPES_SUPPORTED = ["registration", "node", "query", "connection"]
+SCOPES_SUPPORTED = ["registration", "node", "query", "connection", "netctrl", "events", "channelmapping"]
 GRANT_TYPES_SUPPORTED = ["authorization_code", "refresh_token", "client_credentials"]
 
 

--- a/nmosauth/auth_server/token_generator.py
+++ b/nmosauth/auth_server/token_generator.py
@@ -20,7 +20,8 @@ from authlib.jose import jwt
 from .oauth2 import authorization
 from .constants import NMOSAUTH_DIR, PRIVKEY_FILE
 
-ALLOWED_SCOPES = ["registration", "node", "query", "connection"]
+SCOPES_SUPPORTED = ["registration", "node", "query", "connection"]
+GRANT_TYPES_SUPPORTED = ["authorization_code", "refresh_token", "client_credentials"]
 
 
 class TokenGenerator():
@@ -42,7 +43,7 @@ class TokenGenerator():
         nmos_claim = {}
         if user and scope_list:
             for scope in scope_list:
-                if scope not in ALLOWED_SCOPES:
+                if scope not in SCOPES_SUPPORTED:
                     continue
                 nmos_claim[scope] = {}
                 try:

--- a/nmosauth/auth_server/token_generator.py
+++ b/nmosauth/auth_server/token_generator.py
@@ -19,9 +19,7 @@ from authlib.jose import jwt
 
 from .oauth2 import authorization
 from .constants import NMOSAUTH_DIR, PRIVKEY_FILE
-
-SCOPES_SUPPORTED = ["registration", "node", "query", "connection", "netctrl", "events", "channelmapping"]
-GRANT_TYPES_SUPPORTED = ["authorization_code", "refresh_token", "client_credentials"]
+from .metadata import SCOPES_SUPPORTED
 
 
 class TokenGenerator():

--- a/setup.py
+++ b/setup.py
@@ -15,12 +15,13 @@
 # limitations under the License.
 
 from __future__ import print_function
+
 import os
-from setuptools import setup
 import subprocess
+
+from setuptools import setup
 from setuptools.command.develop import develop
 from setuptools.command.install import install
-
 from nmosauth.auth_server.constants import NMOSAUTH_DIR
 
 GEN_CERT_FILE = 'gen_cert.py'
@@ -29,7 +30,7 @@ GEN_CERT_PATH = os.path.join(NMOSAUTH_DIR, GEN_CERT_FILE)
 
 # Basic metadata
 name = "nmos-auth"
-version = "1.4.3"
+version = "1.4.4"
 description = "OAuth2 Server Implementation"
 url = 'https://github.com/bbc/nmos-auth-server'
 author = 'Danny Meloy'

--- a/tests/nmos_auth_data.py
+++ b/tests/nmos_auth_data.py
@@ -12,46 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-EQUIVALENT TO:
-{
-  "sub": "dannym",
-  "exp": 1582136965,
-  "scope": "is-05",
-  "iss": "http://rd.bbc.co.uk/x-nmos/auth/v1.0/",
-  "iat": 1550579365,
-  "x-nmos-api": {
-    "access": "write",
-    "name": "is-05"
-  },
-  "nbf": 1550579365,
-  "aud": [
-    "IS-05",
-    "Write",
-    "Access"
-  ]
-}
-"""
-
-BEARER_TOKEN = {
-    "access_token": '''
-eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJkYW5ueW0iLCJleHAi\
-OjE1ODIxMzY5NjUsInNjb3BlIjoiaXMtMDUiLCJpc3MiOiJodHRwczovL29hdXRoL\
-nJkLmJiYy5jby51ayIsImlhdCI6MTU1MDU3OTM2NSwieC1ubW9zLWFwaSI6eyJhY2\
-Nlc3MiOiJ3cml0ZSIsIm5hbWUiOiJpcy0wNSJ9LCJuYmYiOjE1NTA1NzkzNjUsImF\
-1ZCI6WyJJUy0wNSIsIldyaXRlIiwiQWNjZXNzIl19.UQYw_Br8uyYWYUbPSbZO3Bb\
-hU16eOExZ2cZnIvOdp8lr0ZCZbytrKrEQr1ahZ3d49c9UxC0paK4FWYPHSZ3xxANh\
-1AbhyR2ziybDtOM6rJ-5EdljhLaRLTeVpwhghP1QXwQj-vJWsFvqWAj13ij7S2ek8\
-Uj_UHyrJoSjQniYDwZBB2mHoIl5MyX1yCo-h1tqCcdLZZY6RyIvVME6TUR_GzrMep\
-g66DXfjVe7DDmcXH7hfhVMTdSu4N-z-ipV4L63RXjCEZbkY-_o-9houtzv-rSPFTc\
-ILj_HC0Io8enTvnSYKgKOBEIjIZOMOFp68OEmqfjM1cBwV9TrKLO160U6tA\
-''',
-    "expires_in": 864000,
-    "refresh_token": "Le2WDVvPvifiSq0sdsi7vGfmXwLPxkqhpfVsQrH1j9n4NxnU",
-    "scope": "is04",
-    "token_type": "Bearer"
-}
-
 CERT = {
     "default": '''-----BEGIN CERTIFICATE-----
 MIIDYzCCAkugAwIBAgIJAOx6GjodUN5yMA0GCSqGSIb3DQEBCwUAMEgxCzAJBgNV

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -27,7 +27,7 @@ from werkzeug.security import generate_password_hash, check_password_hash
 from nmoscommon.logger import Logger
 from nmosauth.auth_server.db_utils import drop_all
 from nmosauth.auth_server.models import AdminUser
-from nmosauth.auth_server.token_generator import GRANT_TYPES_SUPPORTED
+from nmosauth.auth_server.metadata import GRANT_TYPES_SUPPORTED, SCOPES_SUPPORTED, RESPONSE_TYPES_SUPPORTED
 from nmosauth.auth_server.security_api import SecurityAPI
 from nmos_auth_data import TEST_PRIV_KEY
 
@@ -165,10 +165,10 @@ class TestNmosAuthServer(unittest.TestCase):
         self.register_data = {
             'client_name': 'R&D Web Router',
             'client_uri': 'http://ipstudio-master.rd.bbc.co.uk/ips-web/#/web-router',
-            'scope': 'registration query',
+            'scope': ' '.join(SCOPES_SUPPORTED),
             'redirect_uris': ['http://www.example.com'],
-            'grant_types': ['password', 'authorization_code', 'refresh_token'],
-            'response_types': ['code'],
+            'grant_types': GRANT_TYPES_SUPPORTED,
+            'response_types': RESPONSE_TYPES_SUPPORTED,
             'token_endpoint_auth_method': 'client_secret_basic'
         }
         with self.client as client:


### PR DESCRIPTION
This PR contains:
- Added compatability for IS-06, IS-07, IS-08
- Pulled the metadata endpoint creation out into a seperate file/function (and added more fields to metadata endpoint)
- Use authlib's client registration endpoint class as a way of validating the input to the register client endpoint (this validation occurs based on the metadata endpoint information defined in the above change)
- Changed var names to be more readable
- Changed the server so it no longer supports the password grant and therefore changed the request_token endpoint so it uses the client credentials grant
- Updated tests format (refactored monolithic function and added refresh token tests)
